### PR TITLE
Add engine API to the black-box design

### DIFF
--- a/specs/design-black-box.md
+++ b/specs/design-black-box.md
@@ -121,7 +121,7 @@ type Engine interface {
 	// OnSyncCompleted registers callback that is executed after each sync operation.
 	OnSyncCompleted(callback func(appName string, state appv1.OperationState) error) Unsubscribe
 
-	// OnClusterCacheInitialized registers that that is executed when cluster cache initialization is completed.
+	// OnClusterCacheInitialized registers a callback that is executed when cluster cache initialization is completed.
 	OnClusterCacheInitialized(callback func(server string)) Unsubscribe
 
 	// OnResourceUpdated registers that that is executed when cluster resource got updated.

--- a/specs/design-black-box.md
+++ b/specs/design-black-box.md
@@ -86,7 +86,7 @@ gitops-engine
 |   |-- utils
 |   |   |-- diff   # provides Kubernetes resource diffing functionality
 |   |   |-- kube   # provides utility methods to interact with Kubernetes
-|   |   |-- lue    # provides utility methods to run Lua scripts
+|   |   |-- lua    # provides utility methods to run Lua scripts
 |   |   |-- apps   # provides utility methods to manipulate Applications (e.g. start sync operation, wait for sync operation, force reconciliation)
 |   |   `-- health # provides Kubernetes resources health assessment
 |   |-- app

--- a/specs/design-black-box.md
+++ b/specs/design-black-box.md
@@ -163,7 +163,7 @@ type ManifestResponse struct {
     // Generated manifests
     Manifests  []string
     // Resolved Git revision
-	Revision   string
+    Revision   string
 }
 
 type ManifestGenerator interface {

--- a/specs/design-black-box.md
+++ b/specs/design-black-box.md
@@ -157,7 +157,7 @@ type CredentialsStore interface {
 }
 ```
 
-**ManifestGenerator** an golang interface that must be implemented by the GitOps engine consumer.
+**ManifestGenerator** a Golang interface that must be implemented by the GitOps engine consumer.
 ```golang
 type ManifestResponse struct {
     // Generated manifests

--- a/specs/design-black-box.md
+++ b/specs/design-black-box.md
@@ -127,7 +127,7 @@ type Engine interface {
 	// OnResourceUpdated registers that that is executed when cluster resource got updated.
 	OnResourceUpdated(callback func(cluster string, un *unstructured.Unstructured)) Unsubscribe
 
-	// OnResourceRemoved registers that that is executed when cluster resource got removed.
+	// OnResourceRemoved registers a callback that is executed when a cluster resource gets removed.
 	OnResourceRemoved(callback func(cluster string, key kube.ResourceKey)) Unsubscribe
 
 	// OnAppEvent registers callback that is executed on every application event.

--- a/specs/design-black-box.md
+++ b/specs/design-black-box.md
@@ -124,7 +124,7 @@ type Engine interface {
 	// OnClusterCacheInitialized registers a callback that is executed when cluster cache initialization is completed.
 	OnClusterCacheInitialized(callback func(server string)) Unsubscribe
 
-	// OnResourceUpdated registers that that is executed when cluster resource got updated.
+	// OnResourceUpdated registers a callback that is executed when cluster resource got updated.
 	OnResourceUpdated(callback func(cluster string, un *unstructured.Unstructured)) Unsubscribe
 
 	// OnResourceRemoved registers a callback that is executed when a cluster resource gets removed.

--- a/specs/design-black-box.md
+++ b/specs/design-black-box.md
@@ -8,8 +8,8 @@ effort to resolve such differences it is proposed contributing missing features 
 
 ## Proposal
 
-It is proposed to use Argo CD application controller as the base for the GitOps engine and contribute a set of Flux features into it. There are two main reasons to try using Argo CD as
-a base:
+It is proposed to use Argo CD application controller as the base for the GitOps engine and contribute a set of Flux features into it. There are two main reasons to try using
+Argo CD as a base:
 - Argo CD uses the _Application_ abstraction to represent the desired state and target the Kubernetes cluster. This abstraction works for both Argo CD and Flux.
 - The Argo CD controller leverages Kubernetes watch APIs instead of polling. This enables Argo CD features such as Health assessment, UI and could provide better performance to
 Flux as well.
@@ -22,8 +22,8 @@ The following Flux features are missing in Argo CD:
 
 These features must be contributed to Argo-Flux GitOps engine implementation before Flux starts using it.
 
-Flux additionally provides the ability to monitor Docker registry and automatically push changes to the Git repository when a new image is released. Both teams feel the this should not
-be a part of GitOps engine. So it is proposed to keep the feature only in Flux for now and then work together to move it into a separate component that would work for both Flux
+Flux additionally provides the ability to monitor Docker registry and automatically push changes to the Git repository when a new image is released. Both teams feel the this should
+not be a part of GitOps engine. So it is proposed to keep the feature only in Flux for now and then work together to move it into a separate component that would work for both Flux
 and Argo CD.
 
 ### Hypothesis and assumptions
@@ -32,7 +32,8 @@ The proposed solution is based on the assumption that despite implementation dif
 ultimately extract the set of manifests from Git and use "kubectl apply" to change the cluster state. The minor differences are expected but we can resolve them by introducing new
 knobs.
 
-Also, the proposed approach is based on the assumption that Argo CD engine is flexible enough to cover all Flux use-cases, reproduce Flux's behavior with minor differences and can be easily integrated into Argo CD.
+Also, the proposed approach is based on the assumption that Argo CD engine is flexible enough to cover all Flux use-cases, reproduce Flux's behavior with minor differences and can
+be easily integrated into Argo CD.
 
 However, there is a risk that there will be too many differences and it might be not feasible to support all of them. To get early feedback, we will start with a Proof-of-Concept 
 (PoC from now on) implementation which will serve as an experiment to assess the feasibility of the approach.
@@ -192,8 +193,8 @@ type ManifestGenerator interface {
 }
 ```
 
-**Engine instantiation** in order to create engine the consumer must provide the cluster credentials store and manifest generator as well as reconciliation settings. The code snippets
-below contains `NewEngine` function definition and usage example:
+**Engine instantiation** in order to create engine the consumer must provide the cluster credentials store and manifest generator as well as reconciliation settings.
+The code snippets below contains `NewEngine` function definition and usage example:
 
 ```golang
 func NewEngine(settings ReconciliationSettings, creds CredentialsStore, manifests ManifestGenerator)

--- a/specs/design-black-box.md
+++ b/specs/design-black-box.md
@@ -95,7 +95,7 @@ gitops-engine
 |   `-- engine     # the engine implementation
 ```
 
-The engine is responsible for reconciliation only which includes:
+The engine is responsible for the reconciliation of Kubernetes resources, which includes:
 - Interacting with the Kubernetes API: load and maintain the cluster state; pushing required changes to the Kubernetes API.
 - Reconciliation logic: based on provides target resource definition find which resources should be updated/deleted/created.
 - Syncing logic: determine the order in which resources should be modified; features like sync hooks, waves, etc.

--- a/specs/design-black-box.md
+++ b/specs/design-black-box.md
@@ -78,7 +78,7 @@ The proposed design is based on the PoC that contains draft implementation and p
 
 The GitOps engine API consists of three main packages:
 * The `utils` package. It consist of loosely coupled packages that implements K8S resource diffing, health assessment, etc
-* The `syncunit` package that contains SyncUnit data structure definition and CRUD client interface.
+* The `sync<Term>` package that contains Sync<Term> data structure definition and CRUD client interface.
 * The `engine` package that leverages `utils` and uses provided set of Applications as a configuration source.
 
 ```
@@ -88,11 +88,11 @@ gitops-engine
 |   |   |-- diff        # provides Kubernetes resource diffing functionality
 |   |   |-- kube        # provides utility methods to interact with Kubernetes
 |   |   |-- lua         # provides utility methods to run Lua scripts
-|   |   |-- syncunits   # provides utility methods to manipulate SyncUnits (e.g. start sync operation, wait for sync operation, force reconciliation)
+|   |   |-- sync<Term>   # provides utility methods to manipulate Sync<Term> (e.g. start sync operation, wait for sync operation, force reconciliation)
 |   |   `-- health      # provides Kubernetes resources health assessment
-|   |-- syncunit
-|   |   |-- apis       # contains data structures that describe SyncUnits
-|   |   `-- client     # contains client that provides SyncUnit CRUD operations
+|   |-- sync<Term>
+|   |   |-- apis       # contains data structures that describe Sync<Term>
+|   |   `-- client     # contains client that provides Sync<Term> CRUD operations
 |   `-- engine         # the engine implementation
 ```
 
@@ -105,9 +105,11 @@ The manifests generation is out of scope and should be implemented by the Engine
 
 ### Engine API
 
+> `Sync<Term>` is a place holder to a real name. The name is still under discussion
+
 The engine API includes three main parts:
 - `Engine` golang interface
-- `SyncUnit` data structure and `SyncUnitStore` interface which provides access to the units.
+- `Sync<Term>` data structure and `Sync<Term>Store` interface which provides access to the units.
 - Set of data structures which allows configuring reconciliation process.
 
 **Engine interface** - provides set of features that allows updating reconciliation settings and subscribe to engine events.
@@ -126,7 +128,7 @@ type Engine interface {
 	OnSyncCompleted(callback func(appName string, state OperationState) error) Unsubscribe
 
     // OnClusterCacheInitialized registers a callback that is executed when cluster cache initialization is completed.
-    // Callback is useful to wait unit cluster cache is fully initialized before starting to use cached data.
+    // Callback is useful to wait until cluster cache is fully initialized before starting to use cached data.
 	OnClusterCacheInitialized(callback func(server string)) Unsubscribe
 
 	// OnResourceUpdated registers a callback that is executed when cluster resource got updated.
@@ -135,28 +137,28 @@ type Engine interface {
 	// OnResourceRemoved registers a callback that is executed when a cluster resource gets removed.
 	OnResourceRemoved(callback func(cluster string, key kube.ResourceKey)) Unsubscribe
 
-	// OnUnitEvent registers callback that is executed on every sync unit event.
-	OnUnitEvent(callback func(id string, info EventInfo, message string)) Unsubscribe
+	// On<Term>Event registers callback that is executed on every sync <Term> event.
+	On<Term>Event(callback func(id string, info EventInfo, message string)) Unsubscribe
 }
 
 type Unsubscribe func()
 ```
 
-**SyncUnit data structure** - allows engine accessing units and update status.
+**Sync<Term> data structure** - allows engine accessing sync <Term> and update status.
 
 ```golang
-type SyncUnit struct {
+type Sync<Term> struct {
 	ID         string
-	Status      UnitStatus
+	Status      Status
 	Source      ManifestSource
 	Destination ManifestDestination
 	Operation   *Operation
 }
 
-type SyncUnitStore interface {
-	List() ([]SyncUnit, error)
-	Get(id string) (SyncUnit, error)
-	SetStatus(id string, status UnitStatus) (SyncUnit, error)
+type Sync<Term>Store interface {
+	List() ([]Sync<Term>, error)
+	Get(id string) (Sync<Term>, error)
+	SetStatus(id string, status Status) (Sync<Term>, error)
 	SetOperation(id string, operation *Operation) error
 }
 ```

--- a/specs/design-black-box.md
+++ b/specs/design-black-box.md
@@ -124,7 +124,8 @@ type Engine interface {
 	// OnSyncCompleted registers callback that is executed after each sync operation.
 	OnSyncCompleted(callback func(appName string, state OperationState) error) Unsubscribe
 
-	// OnClusterCacheInitialized registers a callback that is executed when cluster cache initialization is completed.
+    // OnClusterCacheInitialized registers a callback that is executed when cluster cache initialization is completed.
+    // Callback is useful to wait unit cluster cache is fully initialized before starting to use cached data.
 	OnClusterCacheInitialized(callback func(server string)) Unsubscribe
 
 	// OnResourceUpdated registers a callback that is executed when cluster resource got updated.
@@ -167,7 +168,7 @@ type ReconciliationSettings struct {
 	// ResourcesFilter holds settigns which allows to configure list of managed resource APIs
 	ResourcesFilter resource.ResourcesFilter
 	// ResourceOverrides holds settings which customize resource diffing logic
-	ResourceOverrides map[string]appv1.ResourceOverride
+	ResourceOverrides map[scheme.GroupKind]appv1.ResourceOverride
 }
 
 // provides access to cluster credentials

--- a/specs/design-black-box.md
+++ b/specs/design-black-box.md
@@ -97,7 +97,7 @@ gitops-engine
 
 The engine is responsible for the reconciliation of Kubernetes resources, which includes:
 - Interacting with the Kubernetes API: load and maintain the cluster state; pushing required changes to the Kubernetes API.
-- Reconciliation logic: based on provides target resource definition find which resources should be updated/deleted/created.
+- Reconciliation logic: match target K8S cluster resources with the resources stored in Git and decide which resources should be updated/deleted/created.
 - Syncing logic: determine the order in which resources should be modified; features like sync hooks, waves, etc.
 
 The manifests generation is out of scope and should be implemented by the Engine consumer.
@@ -106,7 +106,7 @@ The manifests generation is out of scope and should be implemented by the Engine
 
 The engine API includes Application data structure/client and `Engine` golang interface that allows configuring reconciliation process:
 
-**Engine interface** - provides set of that allows updating reconciliation settings and subscribe to engine events.
+**Engine interface** - provides set of features that allows updating reconciliation settings and subscribe to engine events.
 ```golang
 type Engine interface {
 	// Run starts reconciliation loop using specified number of processors for reconciliation and operation execution.


### PR DESCRIPTION
PR adds the target engine API.

The design is only inspired by PoC but represents that final state so pretty different from the implemented changes.