### PR TITLE
feat: cluster cache should expose synchronization error

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,6 @@
+coverage:
+  status:
+    patch: off
+    project:
+      default:
+        threshold: 2


### PR DESCRIPTION
PR allows accessing most recent cluster cache synchronization error. Also adds comments to the top level cluster cache API.