### PR TITLE
chore: Speficy correct module dependency for kube-aggregator

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	k8s.io/apimachinery v0.16.6
 	k8s.io/cli-runtime v0.16.6
 	k8s.io/client-go v11.0.1-0.20190816222228-6d55c1b1f1ca+incompatible
-	k8s.io/kube-aggregator v0.0.0
+	k8s.io/kube-aggregator v0.16.6
 	k8s.io/kubectl v0.16.6
 	k8s.io/kubernetes v1.16.6
 )


### PR DESCRIPTION
Fixes #38 