### PR TITLE
refactor: add methods in errors package to quit with exit codes

### DIFF
--- a/agent/main.go
+++ b/agent/main.go
@@ -119,10 +119,10 @@ func newCmd() *cobra.Command {
 			}
 			s := settings{args[0], paths}
 			config, err := clientConfig.ClientConfig()
-			errors.CheckError(err)
+			errors.CheckErrorWithCode(err, errors.ErrorCommandSpecific)
 			if namespace == "" {
 				namespace, _, err = clientConfig.Namespace()
-				errors.CheckError(err)
+				errors.CheckErrorWithCode(err, errors.ErrorCommandSpecific)
 			}
 
 			var namespaces []string
@@ -141,10 +141,10 @@ func newCmd() *cobra.Command {
 				}),
 			)
 			gitOpsEngine := engine.NewEngine(config, clusterCache)
-			errors.CheckError(err)
+			errors.CheckErrorWithCode(err, errors.ErrorCommandSpecific)
 
 			closer, err := gitOpsEngine.Run()
-			errors.CheckError(err)
+			errors.CheckErrorWithCode(err, errors.ErrorCommandSpecific)
 
 			defer io.Close(closer)
 
@@ -162,7 +162,7 @@ func newCmd() *cobra.Command {
 				resync <- true
 			})
 			go func() {
-				errors.CheckError(http.ListenAndServe(fmt.Sprintf("0.0.0.0:%d", port), nil))
+				errors.CheckErrorWithCode(http.ListenAndServe(fmt.Sprintf("0.0.0.0:%d", port), nil), errors.ErrorCommandSpecific)
 			}()
 
 			for ; true; <-resync {

--- a/pkg/cache/cluster_test.go
+++ b/pkg/cache/cluster_test.go
@@ -18,7 +18,6 @@ import (
 	"k8s.io/client-go/dynamic/fake"
 	"k8s.io/client-go/rest"
 
-	"github.com/argoproj/gitops-engine/pkg/utils/errors"
 	"github.com/argoproj/gitops-engine/pkg/utils/kube"
 	"github.com/argoproj/gitops-engine/pkg/utils/kube/kubetest"
 )
@@ -26,7 +25,9 @@ import (
 func strToUnstructured(jsonStr string) *unstructured.Unstructured {
 	obj := make(map[string]interface{})
 	err := yaml.Unmarshal([]byte(jsonStr), &obj)
-	errors.CheckError(err)
+	if err != nil {
+		panic(err)
+	}
 	return &unstructured.Unstructured{Object: obj}
 }
 

--- a/pkg/diff/diff_test.go
+++ b/pkg/diff/diff_test.go
@@ -18,8 +18,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
-
-	"github.com/argoproj/gitops-engine/pkg/utils/errors"
 )
 
 var (
@@ -56,16 +54,22 @@ func toUnstructured(obj interface{}) (*unstructured.Unstructured, error) {
 
 func mustToUnstructured(obj interface{}) *unstructured.Unstructured {
 	un, err := toUnstructured(obj)
-	errors.CheckError(err)
+	if err != nil {
+		panic(err)
+	}
 	return un
 }
 
 func unmarshalFile(path string) *unstructured.Unstructured {
 	data, err := ioutil.ReadFile(path)
-	errors.CheckError(err)
+	if err != nil {
+		panic(err)
+	}
 	var un unstructured.Unstructured
 	err = json.Unmarshal(data, &un.Object)
-	errors.CheckError(err)
+	if err != nil {
+		panic(err)
+	}
 	return &un
 }
 

--- a/pkg/utils/errors/errors.go
+++ b/pkg/utils/errors/errors.go
@@ -1,18 +1,55 @@
 package errors
 
 import (
+	"os"
+
 	log "github.com/sirupsen/logrus"
 )
 
-// CheckError is a convenience function to exit if an error is non-nil and exit if it was
-func CheckError(err error) {
+const (
+	// ErrorCommandSpecific is reserved for command specific indications
+	ErrorCommandSpecific = 1
+	// ErrorConnectionFailure is returned on connection failure to API endpoint
+	ErrorConnectionFailure = 11
+	// ErrorAPIResponse is returned on unexpected API response, i.e. authorization failure
+	ErrorAPIResponse = 12
+	// ErrorResourceDoesNotExist is returned when the requested resource does not exist
+	ErrorResourceDoesNotExist = 13
+	// ErrorGeneric is returned for generic error
+	ErrorGeneric = 20
+)
+
+// CheckErrorWithCode is a convenience function to exit if an error is non-nil and exit if it was
+func CheckErrorWithCode(err error, exitcode int) {
 	if err != nil {
-		log.Fatal(err)
+		Fatal(exitcode, err)
 	}
 }
 
-// panics if there is an error.
-// This returns the first value so you can use it if you cast it:
+// Fatal is a wrapper for logrus.Fatal() to exit with custom code
+func Fatal(exitcode int, args ...interface{}) {
+	exitfunc := func() {
+		os.Exit(exitcode)
+	}
+	log.RegisterExitHandler(exitfunc)
+	log.Fatal(args...)
+}
+
+// Fatalf is a wrapper for logrus.Fatalf() to exit with custom code
+func Fatalf(exitcode int, format string, args ...interface{}) {
+	exitfunc := func() {
+		os.Exit(exitcode)
+	}
+	log.RegisterExitHandler(exitfunc)
+	log.Fatalf(format, args...)
+}
+
+// CheckError logs a fatal message and exits with ErrorGeneric if err is not nil
+func CheckError(err error) {
+	Fatal(ErrorGeneric, err)
+}
+
+// FailOnErr panics if there is an error. It returns the first value so you can use it if you cast it:
 // text := FailOrErr(Foo)).(string)
 func FailOnErr(v interface{}, err error) interface{} {
 	CheckError(err)


### PR DESCRIPTION
This is a part of Streamline exit codes of CLI (https://github.com/argoproj/argo-cd/issues/3592) issue on argo-cd.  
Continued from where @jannfis [left off](https://github.com/jannfis/argo-cd/commit/4b5574ed8509098476a4bf672a5c7e8020e82b6a)

Signed-off-by: darshanime <deathbullet@gmail.com>