### PR TITLE
fix: race condition (#50)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ generate: agent-manifests
 
 .PHONY: test
 test:
-	go test ./... -coverprofile=coverage.out
+	go test ./... --race -coverprofile=coverage.out
 
 .PHONY: lint
 lint:

--- a/pkg/cache/cluster.go
+++ b/pkg/cache/cluster.go
@@ -545,13 +545,9 @@ func (c *clusterCache) startMissingWatches() error {
 	return nil
 }
 
-func runSynced(action func() error) error {
-	return action()
-}
-
 func (c *clusterCache) watchEvents(ctx context.Context, api kube.APIResourceInfo, info *apiMeta, resClient dynamic.ResourceInterface, ns string) {
 	kube.RetryUntilSucceed(func() error {
-		err := runSynced(func() error {
+		err := func() error {
 			version, err := info.LoadResourceVersion()
 			if err != nil {
 				return err
@@ -588,7 +584,7 @@ func (c *clusterCache) watchEvents(ctx context.Context, api kube.APIResourceInfo
 				}
 			}
 			return nil
-		})
+		}()
 
 		if err != nil {
 			return err
@@ -638,10 +634,7 @@ func (c *clusterCache) watchEvents(ctx context.Context, api kube.APIResourceInfo
 								}
 							}
 						} else {
-							err = runSynced(func() error {
-								return c.startMissingWatches()
-							})
-
+							err = c.startMissingWatches()
 						}
 					}
 					if err != nil {

--- a/pkg/cache/cluster_test.go
+++ b/pkg/cache/cluster_test.go
@@ -356,7 +356,8 @@ func TestWatchCacheUpdated(t *testing.T) {
 	podGroupKind := testPod.GroupVersionKind().GroupKind()
 
 	cluster.lock.Lock()
-	cluster.replaceResourceCache(podGroupKind, "updated-list-version", []unstructured.Unstructured{*updated, *added}, "")
+	err = cluster.replaceResourceCache(podGroupKind, "updated-list-version", []unstructured.Unstructured{*updated, *added}, "")
+	assert.Nil(t, err)
 
 	_, ok := cluster.resources[kube.GetResourceKey(removed)]
 	assert.False(t, ok)
@@ -375,7 +376,8 @@ func TestNamespaceModeReplace(t *testing.T) {
 	err := cluster.EnsureSynced()
 	assert.Nil(t, err)
 
-	cluster.replaceResourceCache(podGroupKind, "", nil, "ns1")
+	err = cluster.replaceResourceCache(podGroupKind, "", nil, "ns1")
+	assert.Nil(t, err)
 
 	_, ok := cluster.resources[kube.GetResourceKey(ns1Pod)]
 	assert.False(t, ok)

--- a/pkg/cache/cluster_test.go
+++ b/pkg/cache/cluster_test.go
@@ -141,7 +141,7 @@ func TestEnsureSynced(t *testing.T) {
 	err := cluster.EnsureSynced()
 	assert.Nil(t, err)
 
-	assert.Equal(t, cluster.ResourcesLength(), 2)
+	assert.Equal(t, cluster.resources.Length(), 2)
 	var names []string
 	cluster.resources.Range(func(key, value interface{}) bool {
 		k, _ := key.(kube.ResourceKey)
@@ -168,7 +168,7 @@ func TestEnsureSyncedSingleNamespace(t *testing.T) {
 	err := cluster.EnsureSynced()
 	assert.Nil(t, err)
 
-	assert.Equal(t, cluster.ResourcesLength(), 1)
+	assert.Equal(t, cluster.resources.Length(), 1)
 	var names []string
 	cluster.resources.Range(func(key, value interface{}) bool {
 		k, _ := key.(kube.ResourceKey)

--- a/pkg/cache/cluster_test.go
+++ b/pkg/cache/cluster_test.go
@@ -141,7 +141,7 @@ func TestEnsureSynced(t *testing.T) {
 	err := cluster.EnsureSynced()
 	assert.Nil(t, err)
 
-	assert.Equal(t, cluster.resources.Length(), 2)
+	assert.Equal(t, cluster.resources.length(), 2)
 	var names []string
 	cluster.resources.Range(func(key, value interface{}) bool {
 		k, _ := key.(kube.ResourceKey)
@@ -168,7 +168,7 @@ func TestEnsureSyncedSingleNamespace(t *testing.T) {
 	err := cluster.EnsureSynced()
 	assert.Nil(t, err)
 
-	assert.Equal(t, cluster.resources.Length(), 1)
+	assert.Equal(t, cluster.resources.length(), 1)
 	var names []string
 	cluster.resources.Range(func(key, value interface{}) bool {
 		k, _ := key.(kube.ResourceKey)
@@ -200,20 +200,20 @@ func TestGetNamespaceResources(t *testing.T) {
 	assert.Nil(t, err)
 
 	resources := cluster.GetNamespaceTopLevelResources("default")
-	assert.Equal(t, resources.Length(), 2)
+	assert.Equal(t, resources.length(), 2)
 
-	default1, err := resources.LoadResources(kube.GetResourceKey(defaultNamespaceTopLevel1))
+	default1, err := resources.loadResources(kube.GetResourceKey(defaultNamespaceTopLevel1))
 	assert.Nil(t, err)
 	assert.Equal(t, default1.Ref.Name, "helm-guestbook1")
 
-	default2, err := resources.LoadResources(kube.GetResourceKey(defaultNamespaceTopLevel2))
+	default2, err := resources.loadResources(kube.GetResourceKey(defaultNamespaceTopLevel2))
 	assert.Nil(t, err)
 	assert.Equal(t, default2.Ref.Name, "helm-guestbook2")
 
 	resources = cluster.GetNamespaceTopLevelResources("kube-system")
-	assert.Equal(t, resources.Length(), 1)
+	assert.Equal(t, resources.length(), 1)
 
-	system2, err := resources.LoadResources(kube.GetResourceKey(kubesystemNamespaceTopLevel2))
+	system2, err := resources.loadResources(kube.GetResourceKey(kubesystemNamespaceTopLevel2))
 	assert.Nil(t, err)
 	assert.Equal(t, system2.Ref.Name, "helm-guestbook3")
 }

--- a/pkg/cache/cluster_test.go
+++ b/pkg/cache/cluster_test.go
@@ -369,7 +369,6 @@ func TestWatchCacheUpdated(t *testing.T) {
 
 	podGroupKind := testPod.GroupVersionKind().GroupKind()
 
-	cluster.lock.Lock()
 	err = cluster.replaceResourceCache(podGroupKind, "updated-list-version", []unstructured.Unstructured{*updated, *added}, "")
 	assert.Nil(t, err)
 

--- a/pkg/cache/resource.go
+++ b/pkg/cache/resource.go
@@ -68,7 +68,7 @@ func (r *Resource) iterateChildren(ns *Resources, parents map[kube.ResourceKey]b
 			return false
 		}
 
-		res, err := ns.LoadResources(childKey)
+		res, err := ns.loadResources(childKey)
 		if err != nil {
 			return false
 		}

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -89,7 +89,7 @@ func (e *gitOpsEngine) Sync(ctx context.Context,
 	}
 
 	resUpdated := make(chan bool)
-	unsubscribe := e.cache.OnResourceUpdated(func(newRes *cache.Resource, oldRes *cache.Resource, namespaceResources map[kube.ResourceKey]*cache.Resource) {
+	unsubscribe := e.cache.OnResourceUpdated(func(newRes *cache.Resource, oldRes *cache.Resource, namespaceResources *cache.Resources) {
 		var key kube.ResourceKey
 		if newRes != nil {
 			key = newRes.ResourceKey()

--- a/pkg/sync/sync_context.go
+++ b/pkg/sync/sync_context.go
@@ -651,7 +651,7 @@ func (sc *syncContext) Terminate() {
 				sc.setResourceResult(task, "", common.OperationFailed, fmt.Sprintf("Failed to delete: %v", err))
 				terminateSuccessful = false
 			} else {
-				sc.setResourceResult(task, "", common.OperationSucceeded, fmt.Sprintf("Deleted"))
+				sc.setResourceResult(task, "", common.OperationSucceeded, "Deleted")
 			}
 		} else {
 			sc.setResourceResult(task, "", phase, msg)

--- a/pkg/sync/sync_context.go
+++ b/pkg/sync/sync_context.go
@@ -692,10 +692,10 @@ var operationPhases = map[common.ResultCode]common.OperationPhase{
 }
 
 // tri-state
-type runState = int
+type runState int
 
 const (
-	successful = iota
+	successful runState = iota
 	pending
 	failed
 )

--- a/pkg/utils/kube/ctl.go
+++ b/pkg/utils/kube/ctl.go
@@ -2,7 +2,6 @@ package kube
 
 import (
 	"bytes"
-	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -502,19 +501,12 @@ func (k *KubectlCmd) SetOnKubectlRun(onKubectlRun func(command string) (io.Close
 }
 
 func RunAllAsync(count int, action func(i int) error) error {
-	g, ctx := errgroup.WithContext(context.Background())
-loop:
+	var eg errgroup.Group
 	for i := 0; i < count; i++ {
 		index := i
-		g.Go(func() error {
+		eg.Go(func() error {
 			return action(index)
 		})
-		select {
-		case <-ctx.Done():
-			// Something went wrong already, stop spawning tasks.
-			break loop
-		default:
-		}
 	}
-	return g.Wait()
+	return eg.Wait()
 }


### PR DESCRIPTION
refs: https://github.com/argoproj/gitops-engine/issues/50

If you import the code from https://github.com/argoproj/gitops-engine/pull/52, the race condition will be gone.

```shell
# refs: https://github.com/argoproj/gitops-engine/pull/52
$ git status
On branch feature/fix-race-condition
Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git restore <file>..." to discard changes in working directory)
        modified:   pkg/sync/sync_context_test.go
        modified:   pkg/utils/kube/kubetest/mock.go

no changes added to commit (use "git add" and/or "git commit -a")

$ go test ./... --race
?       github.com/argoproj/gitops-engine       [no test files]
?       github.com/argoproj/gitops-engine/agent [no test files]
ok      github.com/argoproj/gitops-engine/pkg/cache     (cached)
?       github.com/argoproj/gitops-engine/pkg/cache/mocks       [no test files]
ok      github.com/argoproj/gitops-engine/pkg/diff      (cached)
?       github.com/argoproj/gitops-engine/pkg/engine    [no test files]
ok      github.com/argoproj/gitops-engine/pkg/health    (cached)
ok      github.com/argoproj/gitops-engine/pkg/sync      (cached)
ok      github.com/argoproj/gitops-engine/pkg/sync/common       (cached)
ok      github.com/argoproj/gitops-engine/pkg/sync/hook (cached)
ok      github.com/argoproj/gitops-engine/pkg/sync/hook/helm    (cached)
ok      github.com/argoproj/gitops-engine/pkg/sync/ignore       (cached)
ok      github.com/argoproj/gitops-engine/pkg/sync/resource     (cached)
ok      github.com/argoproj/gitops-engine/pkg/sync/syncwaves    (cached)
?       github.com/argoproj/gitops-engine/pkg/utils/errors      [no test files]
ok      github.com/argoproj/gitops-engine/pkg/utils/exec        (cached)
?       github.com/argoproj/gitops-engine/pkg/utils/io  [no test files]
?       github.com/argoproj/gitops-engine/pkg/utils/json        [no test files]
ok      github.com/argoproj/gitops-engine/pkg/utils/kube        (cached)
?       github.com/argoproj/gitops-engine/pkg/utils/kube/kubetest       [no test files]
?       github.com/argoproj/gitops-engine/pkg/utils/testing     [no test files]
?       github.com/argoproj/gitops-engine/pkg/utils/text        [no test files]
ok      github.com/argoproj/gitops-engine/pkg/utils/tracing     (cached)
```

Among many functions, using `sync.Mutex` to secure a lock was complex and difficult.
I took the approach of using `sync.Map`.
I don't think this is the best response, but I think it's good that race conditions are gone.
If you have any comments, please feel free to do so!