### PR TITLE
fix: Lock to write MockKubectlCmd.LastValidate to fix the race condition

### DIFF
--- a/pkg/sync/sync_context_test.go
+++ b/pkg/sync/sync_context_test.go
@@ -73,7 +73,7 @@ func TestSyncValidate(t *testing.T) {
 	syncCtx.Sync()
 
 	kubectl := syncCtx.kubectl.(*kubetest.MockKubectlCmd)
-	assert.False(t, kubectl.LastValidate)
+	assert.False(t, kubectl.GetLastValidate())
 }
 
 func TestSyncNotPermittedNamespace(t *testing.T) {
@@ -393,7 +393,7 @@ func TestSyncOptionValidate(t *testing.T) {
 			syncCtx.Sync()
 
 			kubectl, _ := syncCtx.kubectl.(*kubetest.MockKubectlCmd)
-			assert.Equal(t, tt.want, kubectl.LastValidate)
+			assert.Equal(t, tt.want, kubectl.GetLastValidate())
 		})
 	}
 }


### PR DESCRIPTION
https://github.com/argoproj/gitops-engine/issues/50

```
$ go test -race ./...
```

<details>

```
WARNING: DATA RACE
Write at 0x00c000818098 by goroutine 80:
  github.com/argoproj/gitops-engine/pkg/utils/kube/kubetest.(*MockKubectlCmd).ApplyResource()
      /Users/shunsuke-suzuki/repos/src/github.com/argoproj/gitops-engine/pkg/utils/kube/kubetest/mock.go:56 +0x56
  github.com/argoproj/gitops-engine/pkg/sync.(*syncContext).applyObject()
      /Users/shunsuke-suzuki/repos/src/github.com/argoproj/gitops-engine/pkg/sync/sync_context.go:572 +0x1a8
  github.com/argoproj/gitops-engine/pkg/sync.(*syncContext).runTasks.func5.1()
      /Users/shunsuke-suzuki/repos/src/github.com/argoproj/gitops-engine/pkg/sync/sync_context.go:783 +0x375

Previous write at 0x00c000818098 by goroutine 79:
  github.com/argoproj/gitops-engine/pkg/utils/kube/kubetest.(*MockKubectlCmd).ApplyResource()
      /Users/shunsuke-suzuki/repos/src/github.com/argoproj/gitops-engine/pkg/utils/kube/kubetest/mock.go:56 +0x56
  github.com/argoproj/gitops-engine/pkg/sync.(*syncContext).applyObject()
      /Users/shunsuke-suzuki/repos/src/github.com/argoproj/gitops-engine/pkg/sync/sync_context.go:572 +0x1a8
  github.com/argoproj/gitops-engine/pkg/sync.(*syncContext).runTasks.func5.1()
      /Users/shunsuke-suzuki/repos/src/github.com/argoproj/gitops-engine/pkg/sync/sync_context.go:783 +0x375

Goroutine 80 (running) created at:
  github.com/argoproj/gitops-engine/pkg/sync.(*syncContext).runTasks.func5()
      /Users/shunsuke-suzuki/repos/src/github.com/argoproj/gitops-engine/pkg/sync/sync_context.go:778 +0x1ce
  github.com/argoproj/gitops-engine/pkg/sync.(*syncContext).runTasks()
      /Users/shunsuke-suzuki/repos/src/github.com/argoproj/gitops-engine/pkg/sync/sync_context.go:807 +0xd12
  github.com/argoproj/gitops-engine/pkg/sync.(*syncContext).Sync()
      /Users/shunsuke-suzuki/repos/src/github.com/argoproj/gitops-engine/pkg/sync/sync_context.go:265 +0x1e4d
  github.com/argoproj/gitops-engine/pkg/sync.TestSyncFailureHookWithSuccessfulSync()
      /Users/shunsuke-suzuki/repos/src/github.com/argoproj/gitops-engine/pkg/sync/sync_context_test.go:513 +0x277
  testing.tRunner()
      /usr/local/Cellar/go/1.14.3/libexec/src/testing/testing.go:991 +0x1eb

Goroutine 79 (finished) created at:
  github.com/argoproj/gitops-engine/pkg/sync.(*syncContext).runTasks.func5()
      /Users/shunsuke-suzuki/repos/src/github.com/argoproj/gitops-engine/pkg/sync/sync_context.go:778 +0x1ce
  github.com/argoproj/gitops-engine/pkg/sync.(*syncContext).runTasks()
      /Users/shunsuke-suzuki/repos/src/github.com/argoproj/gitops-engine/pkg/sync/sync_context.go:807 +0xd12
  github.com/argoproj/gitops-engine/pkg/sync.(*syncContext).Sync()
      /Users/shunsuke-suzuki/repos/src/github.com/argoproj/gitops-engine/pkg/sync/sync_context.go:265 +0x1e4d
  github.com/argoproj/gitops-engine/pkg/sync.TestSyncFailureHookWithSuccessfulSync()
      /Users/shunsuke-suzuki/repos/src/github.com/argoproj/gitops-engine/pkg/sync/sync_context_test.go:513 +0x277
  testing.tRunner()
      /usr/local/Cellar/go/1.14.3/libexec/src/testing/testing.go:991 +0x1eb
```

</details>


https://github.com/argoproj/gitops-engine/blob/7d7218e6d61758ff9edb83e80751b67cf28ba020/pkg/sync/sync_context.go#L783

`syncContext.applyObject` is called in parallel, so `MockKubectlCmd.LastValidate` should be 
 thread safe.