### PR TITLE
chore: Add IgnoreResourceStatusField field to DiffOptions

### DIFF
--- a/pkg/diff/diff.go
+++ b/pkg/diff/diff.go
@@ -31,7 +31,8 @@ import (
 // Holds diffing settings
 type DiffOptions struct {
 	// If set to true then differences caused by aggregated roles in RBAC resources are ignored.
-	IgnoreAggregatedRoles bool `json:"ignoreAggregatedRoles,omitempty"`
+	IgnoreAggregatedRoles     bool   `json:"ignoreAggregatedRoles,omitempty"`
+	IgnoreResourceStatusField string `json:"ignoreResourceStatusField,omitempty"`
 }
 
 // Holds diffing result of two resources


### PR DESCRIPTION
Can be used to ignore `/status` of the objects. 
See https://github.com/argoproj/argo-cd/pull/3754 