### PR TITLE
refactor: Drop github.com/grpc-ecosystem/grpc-gateway dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,6 @@ require (
 	github.com/evanphx/json-patch v4.2.0+incompatible
 	github.com/ghodss/yaml v1.0.0
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
-	github.com/grpc-ecosystem/grpc-gateway v1.3.1
 	github.com/k0kubun/colorstring v0.0.0-20150214042306-9440f1994b88 // indirect
 	github.com/pkg/errors v0.9.1
 	github.com/sergi/go-diff v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -269,8 +269,6 @@ github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0 h1:Ovs26xHkKqVztRpIrF/92Bcuy
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgfV/d3M/q6VIi02HzZEHgUlZvzk=
 github.com/grpc-ecosystem/grpc-gateway v1.3.0 h1:HJtP6RRwj2EpPCD/mhAWzSvLL/dFTdPm1UrWwanoFos=
 github.com/grpc-ecosystem/grpc-gateway v1.3.0/go.mod h1:RSKVYQBd5MCa4OVpNdGskqpgL2+G+NZTnrVHpWWfpdw=
-github.com/grpc-ecosystem/grpc-gateway v1.3.1 h1:k2neygAEBYavP90THffKBVlkASdxu4XiI8cAWuL3MG0=
-github.com/grpc-ecosystem/grpc-gateway v1.3.1/go.mod h1:RSKVYQBd5MCa4OVpNdGskqpgL2+G+NZTnrVHpWWfpdw=
 github.com/hashicorp/go-syslog v1.0.0/go.mod h1:qPfqrKkXGihmCqbJM2mZgkZGvKG1dFdvsLplgctolz4=
 github.com/hashicorp/golang-lru v0.0.0-20180201235237-0fb14efe8c47/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=

--- a/pkg/utils/json/json.go
+++ b/pkg/utils/json/json.go
@@ -1,40 +1,5 @@
 package json
 
-import (
-	"encoding/json"
-	"io"
-
-	gwruntime "github.com/grpc-ecosystem/grpc-gateway/runtime"
-)
-
-// JSONMarshaler is a type which satisfies the grpc-gateway Marshaler interface
-type JSONMarshaler struct{}
-
-// ContentType implements gwruntime.Marshaler.
-func (j *JSONMarshaler) ContentType() string {
-	return "application/json"
-}
-
-// Marshal implements gwruntime.Marshaler.
-func (j *JSONMarshaler) Marshal(v interface{}) ([]byte, error) {
-	return json.Marshal(v)
-}
-
-// NewDecoder implements gwruntime.Marshaler.
-func (j *JSONMarshaler) NewDecoder(r io.Reader) gwruntime.Decoder {
-	return json.NewDecoder(r)
-}
-
-// NewEncoder implements gwruntime.Marshaler.
-func (j *JSONMarshaler) NewEncoder(w io.Writer) gwruntime.Encoder {
-	return json.NewEncoder(w)
-}
-
-// Unmarshal implements gwruntime.Marshaler.
-func (j *JSONMarshaler) Unmarshal(data []byte, v interface{}) error {
-	return json.Unmarshal(data, v)
-}
-
 // https://github.com/ksonnet/ksonnet/blob/master/pkg/kubecfg/diff.go
 func removeFields(config, live interface{}) interface{} {
 	switch c := config.(type) {
@@ -78,13 +43,4 @@ func removeListFields(config, live []interface{}) []interface{} {
 		}
 	}
 	return result
-}
-
-// MustMarshal is a convenience function to marshal an object successfully or panic
-func MustMarshal(v interface{}) []byte {
-	bytes, err := json.Marshal(v)
-	if err != nil {
-		panic(err)
-	}
-	return bytes
 }


### PR DESCRIPTION
gitops-engine does not use the `JSONMarshaler` type and pulling in a dependency for it is not great. Let's remove it please.

I'm trying to optimize the amount of stuff my project, that consumes the gitops-engine, needs to pull down and compile to work.