### PR TITLE
fix: Do not perform client side conversion of K8s resources

### DIFF
--- a/pkg/cache/cluster.go
+++ b/pkg/cache/cluster.go
@@ -727,20 +727,14 @@ func (c *clusterCache) GetManagedLiveObjs(targetObjs []*unstructured.Unstructure
 		}
 
 		if managedObj != nil {
-			converted, err := c.kubectl.ConvertToVersion(managedObj, targetObj.GroupVersionKind().Group, targetObj.GroupVersionKind().Version)
+			converted, err := c.kubectl.GetResource(c.config, targetObj.GroupVersionKind(), managedObj.GetName(), managedObj.GetNamespace())
 			if err != nil {
-				// fallback to loading resource from kubernetes if conversion fails
-				log.Warnf("Failed to convert resource: %v", err)
-				managedObj, err = c.kubectl.GetResource(c.config, targetObj.GroupVersionKind(), managedObj.GetName(), managedObj.GetNamespace())
-				if err != nil {
-					if errors.IsNotFound(err) {
-						return nil
-					}
-					return err
+				if errors.IsNotFound(err) {
+					return nil
 				}
-			} else {
-				managedObj = converted
+				return err
 			}
+			managedObj = converted
 			lock.Lock()
 			managedObjs[key] = managedObj
 			lock.Unlock()


### PR DESCRIPTION
Do not perform client side conversion of resources and instead retrieve the converted resource from K8s.

ArgoCD linked to gitops-engine with this change passes end-to-end and unit tests.

Fixes https://github.com/argoproj/argo-cd/issues/3670

