### PR TITLE
fix: change failed conversion log level to debug

### DIFF
--- a/pkg/cache/cluster.go
+++ b/pkg/cache/cluster.go
@@ -730,7 +730,7 @@ func (c *clusterCache) GetManagedLiveObjs(targetObjs []*unstructured.Unstructure
 			converted, err := c.kubectl.ConvertToVersion(managedObj, targetObj.GroupVersionKind().Group, targetObj.GroupVersionKind().Version)
 			if err != nil {
 				// fallback to loading resource from kubernetes if conversion fails
-				log.Warnf("Failed to convert resource: %v", err)
+				log.Debugf("Failed to convert resource: %v", err)
 				managedObj, err = c.kubectl.GetResource(c.config, targetObj.GroupVersionKind(), managedObj.GetName(), managedObj.GetNamespace())
 				if err != nil {
 					if errors.IsNotFound(err) {


### PR DESCRIPTION
Closes https://github.com/argoproj/argo-cd/issues/3670


The warning log level is misleading for this message. PR changes level to debug. 