### PR TITLE
fix: use streaming YAML decoder from Kubernetes

### DIFF
--- a/agent/main.go
+++ b/agent/main.go
@@ -79,7 +79,7 @@ func (s *settings) parseManifests() ([]*unstructured.Unstructured, string, error
 			if err != nil {
 				return err
 			}
-			items, err := kube.SplitYAML(string(data))
+			items, err := kube.SplitYAML(data)
 			if err != nil {
 				return fmt.Errorf("failed to parse %s: %v", path, err)
 			}


### PR DESCRIPTION
apimachinery provides library code to parse multi document YAML, there is no need to resort to regexes. Regexes also don't take into account the document start/end marker that might be somewhere in a string in the middle of a YAML document.