### PR TITLE
fix: sync hooks should be deleted after sync phase/wave completion

### DIFF
--- a/pkg/sync/sync_task.go
+++ b/pkg/sync/sync_task.go
@@ -128,8 +128,11 @@ func (t *syncTask) hasHookDeletePolicy(policy common.HookDeletePolicy) bool {
 	return false
 }
 
-func (t *syncTask) needsDeleting() bool {
-	return t.liveObj != nil && (t.pending() && t.hasHookDeletePolicy(common.HookDeletePolicyBeforeHookCreation) ||
-		t.successful() && t.hasHookDeletePolicy(common.HookDeletePolicyHookSucceeded) ||
+func (t *syncTask) deleteBeforeCreation() bool {
+	return t.liveObj != nil && t.pending() && t.hasHookDeletePolicy(common.HookDeletePolicyBeforeHookCreation)
+}
+
+func (t *syncTask) deleteOnPhaseCompletion() bool {
+	return t.liveObj != nil && (t.successful() && t.hasHookDeletePolicy(common.HookDeletePolicyHookSucceeded) ||
 		t.failed() && t.hasHookDeletePolicy(common.HookDeletePolicyHookFailed))
 }

--- a/pkg/sync/sync_task_test.go
+++ b/pkg/sync/sync_task_test.go
@@ -52,16 +52,22 @@ func Test_syncTask_hasHookDeletePolicy(t *testing.T) {
 	assert.True(t, (&syncTask{targetObj: Annotate(Annotate(NewPod(), "argocd.argoproj.io/hook", "Sync"), "argocd.argoproj.io/hook-delete-policy", "HookFailed")}).hasHookDeletePolicy(common.HookDeletePolicyHookFailed))
 }
 
-func Test_syncTask_needsDeleting(t *testing.T) {
-	assert.False(t, (&syncTask{liveObj: NewPod()}).needsDeleting())
+func Test_syncTask_deleteOnPhaseCompletion(t *testing.T) {
+	assert.False(t, (&syncTask{liveObj: NewPod()}).deleteOnPhaseCompletion())
 	// must be hook
-	assert.False(t, (&syncTask{liveObj: Annotate(NewPod(), "argocd.argoproj.io/hook-delete-policy", "BeforeHookCreation")}).needsDeleting())
+	assert.True(t, (&syncTask{operationState: common.OperationSucceeded, liveObj: Annotate(Annotate(NewPod(), "argocd.argoproj.io/hook", "Sync"), "argocd.argoproj.io/hook-delete-policy", "HookSucceeded")}).deleteOnPhaseCompletion())
+	assert.True(t, (&syncTask{operationState: common.OperationFailed, liveObj: Annotate(Annotate(NewPod(), "argocd.argoproj.io/hook", "Sync"), "argocd.argoproj.io/hook-delete-policy", "HookFailed")}).deleteOnPhaseCompletion())
+}
+
+func Test_syncTask_deleteBeforeCreation(t *testing.T) {
+	assert.False(t, (&syncTask{liveObj: NewPod()}).deleteBeforeCreation())
+	// must be hook
+	assert.False(t, (&syncTask{liveObj: Annotate(NewPod(), "argocd.argoproj.io/hook-delete-policy", "BeforeHookCreation")}).deleteBeforeCreation())
 	// no need to delete if no live obj
-	assert.False(t, (&syncTask{targetObj: Annotate(Annotate(NewPod(), "argoocd.argoproj.io/hook", "Sync"), "argocd.argoproj.io/hook-delete-policy", "BeforeHookCreation")}).needsDeleting())
-	assert.True(t, (&syncTask{liveObj: Annotate(Annotate(NewPod(), "argocd.argoproj.io/hook", "Sync"), "argocd.argoproj.io/hook-delete-policy", "BeforeHookCreation")}).needsDeleting())
-	assert.True(t, (&syncTask{liveObj: Annotate(Annotate(NewPod(), "argocd.argoproj.io/hook", "Sync"), "argocd.argoproj.io/hook-delete-policy", "BeforeHookCreation")}).needsDeleting())
-	assert.True(t, (&syncTask{operationState: common.OperationSucceeded, liveObj: Annotate(Annotate(NewPod(), "argocd.argoproj.io/hook", "Sync"), "argocd.argoproj.io/hook-delete-policy", "HookSucceeded")}).needsDeleting())
-	assert.True(t, (&syncTask{operationState: common.OperationFailed, liveObj: Annotate(Annotate(NewPod(), "argocd.argoproj.io/hook", "Sync"), "argocd.argoproj.io/hook-delete-policy", "HookFailed")}).needsDeleting())
+	assert.False(t, (&syncTask{targetObj: Annotate(Annotate(NewPod(), "argoocd.argoproj.io/hook", "Sync"), "argocd.argoproj.io/hook-delete-policy", "BeforeHookCreation")}).deleteBeforeCreation())
+	assert.True(t, (&syncTask{liveObj: Annotate(Annotate(NewPod(), "argocd.argoproj.io/hook", "Sync"), "argocd.argoproj.io/hook-delete-policy", "BeforeHookCreation")}).deleteBeforeCreation())
+	assert.True(t, (&syncTask{liveObj: Annotate(Annotate(NewPod(), "argocd.argoproj.io/hook", "Sync"), "argocd.argoproj.io/hook-delete-policy", "BeforeHookCreation")}).deleteBeforeCreation())
+
 }
 
 func Test_syncTask_wave(t *testing.T) {


### PR DESCRIPTION
Closes https://github.com/argoproj/argo-cd/issues/2737

PR changes hook deletion logic so that hooks are deleted after sync phase/wave is completed.