### PR TITLE
fix: kube.SplitYAML should support trailing new lines

### DIFF
--- a/agent/main.go
+++ b/agent/main.go
@@ -79,7 +79,7 @@ func (s *settings) parseManifests() ([]*unstructured.Unstructured, string, error
 			if err != nil {
 				return err
 			}
-			items, err := kube.SplitYAML(data)
+			items, err := kube.SplitYAML(string(data))
 			if err != nil {
 				return fmt.Errorf("failed to parse %s: %v", path, err)
 			}

--- a/pkg/utils/kube/kube.go
+++ b/pkg/utils/kube/kube.go
@@ -290,7 +290,9 @@ func newAuthInfo(restConfig *rest.Config) *clientcmdapi.AuthInfo {
 
 // SplitYAML splits a YAML file into unstructured objects. Returns list of all unstructured objects
 // found in the yaml. If an error occurs, returns objects that have been parsed so far too.
-func SplitYAML(yamlData []byte) (retObjs []*unstructured.Unstructured, retErr error) {
+func SplitYAML(yamlStr string) (retObjs []*unstructured.Unstructured, retErr error) {
+	yamlStr = strings.TrimSpace(yamlStr)
+	yamlData := []byte(yamlStr)
 	decoder := streaming.NewDecoder(kubeyaml.NewDocumentDecoder(ioutil.NopCloser(bytes.NewReader(yamlData))), yamlSerializer)
 	defer func() {
 		if err := decoder.Close(); err != nil && retErr == nil {

--- a/pkg/utils/kube/kube_test.go
+++ b/pkg/utils/kube/kube_test.go
@@ -138,3 +138,21 @@ spec:
 	assert.NoError(t, err)
 	assert.Nil(t, GetDeploymentReplicas(&noDeployment))
 }
+
+func TestSplitYAML_SingleObject(t *testing.T) {
+	objs, err := SplitYAML(depWithLabel)
+	assert.NoError(t, err)
+	assert.Len(t, objs, 1)
+}
+
+func TestSplitYAML_MultipleObjects(t *testing.T) {
+	objs, err := SplitYAML(depWithLabel + "\n---\n" + depWithLabel)
+	assert.NoError(t, err)
+	assert.Len(t, objs, 2)
+}
+
+func TestSplitYAML_TrailingNewLines(t *testing.T) {
+	objs, err := SplitYAML("\n\n\n---" + depWithLabel)
+	assert.NoError(t, err)
+	assert.Len(t, objs, 1)
+}


### PR DESCRIPTION
PR restores backward compatibility of `kube.SplitYAML` method:

* changes input type to string
* supports YAML that starts with empty space.