### PR TITLE
feat: support configuring cluster cache re-sync timeout

### DIFF
--- a/pkg/cache/cluster.go
+++ b/pkg/cache/cluster.go
@@ -124,6 +124,7 @@ type ClusterCache interface {
 // NewClusterCache creates new instance of cluster cache
 func NewClusterCache(config *rest.Config, opts ...UpdateSettingsFunc) *clusterCache {
 	cache := &clusterCache{
+		resyncTimeout:           clusterSyncTimeout,
 		settings:                Settings{ResourceHealthOverride: &noopSettings{}, ResourcesFilter: &noopSettings{}},
 		apisMeta:                make(map[schema.GroupKind]*apiMeta),
 		resources:               make(map[kube.ResourceKey]*Resource),
@@ -142,6 +143,7 @@ func NewClusterCache(config *rest.Config, opts ...UpdateSettingsFunc) *clusterCa
 }
 
 type clusterCache struct {
+	resyncTimeout time.Duration
 	syncTime      *time.Time
 	syncError     error
 	apisMeta      map[schema.GroupKind]*apiMeta
@@ -365,7 +367,7 @@ func (c *clusterCache) synced() bool {
 	if c.syncError != nil {
 		return time.Now().Before(syncTime.Add(ClusterRetryTimeout))
 	}
-	return time.Now().Before(syncTime.Add(clusterSyncTimeout))
+	return time.Now().Before(syncTime.Add(c.resyncTimeout))
 }
 
 func (c *clusterCache) stopWatching(gk schema.GroupKind, ns string) {

--- a/pkg/cache/settings.go
+++ b/pkg/cache/settings.go
@@ -2,6 +2,7 @@ package cache
 
 import (
 	"reflect"
+	"time"
 
 	log "github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -73,5 +74,12 @@ func SetConfig(config *rest.Config) UpdateSettingsFunc {
 			log.WithField("server", cache.config.Host).Infof("Changing cluster config to: %v", config)
 			cache.config = config
 		}
+	}
+}
+
+// SetResyncTimeout updates cluster re-sync timeout
+func SetResyncTimeout(timeout time.Duration) UpdateSettingsFunc {
+	return func(cache *clusterCache) {
+		cache.resyncTimeout = timeout
 	}
 }

--- a/pkg/cache/settings_test.go
+++ b/pkg/cache/settings_test.go
@@ -2,6 +2,7 @@ package cache
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"k8s.io/client-go/rest"
@@ -34,4 +35,14 @@ func TestSetNamespaces(t *testing.T) {
 	cache.Invalidate(SetNamespaces(updatedNamespaces))
 
 	assert.ElementsMatch(t, updatedNamespaces, cache.namespaces)
+}
+
+func TestSetResyncTimeout(t *testing.T) {
+	cache := NewClusterCache(&rest.Config{})
+	assert.Equal(t, clusterSyncTimeout, cache.resyncTimeout)
+
+	timeout := 1 * time.Hour
+	cache.Invalidate(SetResyncTimeout(timeout))
+
+	assert.Equal(t, timeout, cache.resyncTimeout)
 }


### PR DESCRIPTION
PR adds the ability to override cluster cache re-sync timeout.