### PR TITLE
docs: Update notes on Argo+Flux collaboration

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@
 
 </div>
 
-Various GitOps operators address different use-cases and provide different user experiences but all have similar set of core features. The teams behind
-[Argo CD](https://github.com/argoproj/argo-cd) and [Flux CD](https://github.com/fluxcd/flux) have implemented a reusable library that implements core GitOps features:
+Various GitOps operators address different use-cases and provide different user experiences but all have similar set of core features. The team behind
+[Argo CD](https://github.com/argoproj/argo-cd) has implemented a reusable library that implements core GitOps features:
 
 - Kubernetes resource cache ✅
 - Resources reconciliation ✅

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -4,11 +4,24 @@
 
 **Q**: What's the backstory behind this?
 
-**A**: The announcement blog posts do quite a good job of explaining where our two projects come from and why it was important for us to take the next step and join our efforts:
+**A**: In November 2019 the teams behind Argo CD and Flux announced that they were going to join efforts. Some of the announcement blog posts explain what the thinking of the time was:
 
 - Jay Pipes on the [AWS blog](https://aws.amazon.com/de/blogs/containers/help-us-write-a-new-chapter-for-gitops-kubernetes-and-open-source-collaboration/)
 - Pratik Wadher on the [Intuit blog](https://www.intuit.com/blog/technology/introducing-argo-flux/)
 - Tamao Nakahara on the [Weaveworks blog](https://www.weave.works/blog/argo-flux-join-forces)
+
+In the course of the next months, the two engineering teams [met on a regular basis](https://docs.google.com/document/d/17AEZgv6yVuD4HS7_oNPiMKmS7Q6vjkhk6jH0YCELpRk/edit) and scoped out the future of the project. Two options were on the table:
+
+1. Rethink APIs and build the project from the ground up.
+1. Extract useful code from Argo into an Engine project.
+
+The latter was deemed to be the most practical solution.
+
+March 2020 the Flux team made a [proof of concept](https://github.com/fluxcd/flux/pull/2886) available, which rebased the Flux on top of the GitOps Engine, but while looking at the breaking changes this was going to introduce the Flux team decided that it was a time for a [more ground-breaking approach](https://www.weave.works/blog/gitops-with-flux-v2) on how to do GitOps. After some experimentation, the GitOps Toolkit was put out as an RFC in June 2020.
+
+The GitOps Engine was and still is the natural evolution for the Argo CD project. A [number of other projects](https://github.com/search?q=argoproj%2Fgitops-engine&type=Code) already started looking at integrating it.
+
+The Argo and Flux teams decided all of this on good terms. All of these discussions were immensely helpful in shaping both projects' future. You might see each of us stealing good ideas from the other in the future and celebrate each others successes. There might be future collaborations, we'll keep you posted.
 
 ----
 
@@ -20,19 +33,6 @@
 - We want to offer a shared vision for GitOps and the best possible GitOps experience for everyone.
 - We hope to bring a bigger community together than we can on our own.
 - We want to learn from each other's approaches and offer the best in breed GitOps solution out there.
-
-----
-
-**Q**: What can current Flux CD users look forward to from this collaboration with Argo CD?
-
-**A**: Here are a few of our favourites:
-
-- Syncing will be more efficient. Instead of polling, Flux CD will use Kubernetes Informers to get information from the cluster.
-- Users will see a great (if not huge) reduction in K8S API calls and etcd traffic.
-- We can increase the syncing frequency.
-- Advanced syncing features such as pre-post sync hooks and sync waves.
-- Overall performance and efficiency improvements (registry scanning excluded) are the major gains for Flux CD users.
-- Given the concept of GitOps is quite young, and all people involved were involved early on (or present during the birth), we hope this will result in an even more experienced team working on core features.
 
 ----
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -19,7 +19,7 @@ The latter was deemed to be the most practical solution.
 
 March 2020 the Flux team made a [proof of concept](https://github.com/fluxcd/flux/pull/2886) available, which rebased the Flux on top of the GitOps Engine, but while looking at the breaking changes this was going to introduce the Flux team decided that it was a time for a [more ground-breaking approach](https://www.weave.works/blog/gitops-with-flux-v2) on how to do GitOps. After some experimentation, the GitOps Toolkit was put out as an RFC in June 2020.
 
-The GitOps Engine was and still is the natural evolution for the Argo CD project. A [number of other projects](https://github.com/search?q=argoproj%2Fgitops-engine&type=Code) already started looking at integrating it.
+A [number of other projects](https://github.com/search?q=argoproj%2Fgitops-engine&type=Code) already started looking at integrating the GitOps Engine.
 
 The Argo and Flux teams decided all of this on good terms. All of these discussions were immensely helpful in shaping both projects' future. You might see each of us stealing good ideas from the other in the future and celebrate each others successes. There might be future collaborations, we'll keep you posted.
 


### PR DESCRIPTION
It's been a while since we wrote most of the docs for the GitOps Engine. In the meantime the Flux project has announced the plans to build Flux v2 on top of the [GitOps Toolkit](https://toolkit.fluxcd.io/). This PR aims to update the docs to reflect this.

For everyone hasn't followed the news closely: This was discussed between project leads of both projects and we consider the time of collaboration as very fruitful: both Argo and Flux developed a new vision on this quest.

Right now this is a draft PR still, some other bits might need updating but I'd defer the decision to maintainers of the GitOps Engine.

What I did in the PR already:

- update main README
- add some more backstory in the FAQ

What I can see as TODO (potentially part of subsequent PRs though):

- update diagram in main README (not sure where the source of this is)
- update other FAQ items to explain the direction and positioning of the GitOps Engine
- quite a few other Flux mentions (might still be useful to keep in spec documents?)

```
[daniel@reef gitops-engine ]$ git grep -i flux | cut -d':' -f1 | uniq -c
     11 docs/faq.md
      4 specs/deployment-repo-update.md
      7 specs/design-bottom-up.md
     22 specs/design-top-down.md
      6 specs/design.md
      3 specs/image-update-monitoring.md
[daniel@reef gitops-engine ]$ 
```

CCing @alexmt @jessesuen @jaypipes @2opremio @hiddeco @squaremo @stefanprodan 