### PR TITLE
fix: check resource namespaces are managed

### DIFF
--- a/pkg/cache/cluster.go
+++ b/pkg/cache/cluster.go
@@ -661,12 +661,33 @@ func (c *clusterCache) IsNamespaced(gk schema.GroupKind) (bool, error) {
 	return false, errors.NewNotFound(schema.GroupResource{Group: gk.Group}, "")
 }
 
+func (c *clusterCache) managesNamespace(namespace string) bool {
+	if len(c.namespaces) == 0 {
+		return true
+	}
+	if len(namespace) == 0 {
+		return true
+	}
+	for _, ns := range c.namespaces {
+		if ns == namespace {
+			return true
+		}
+	}
+	return false
+}
+
 // GetManagedLiveObjs helps finding matching live K8S resources for a given resources list.
 // The function returns all resources from cache for those `isManaged` function returns true and resources
 // specified in targetObjs list.
 func (c *clusterCache) GetManagedLiveObjs(targetObjs []*unstructured.Unstructured, isManaged func(r *Resource) bool) (map[kube.ResourceKey]*unstructured.Unstructured, error) {
 	c.lock.RLock()
 	defer c.lock.RUnlock()
+
+	for _, o := range targetObjs {
+		if !c.managesNamespace(o.GetNamespace()) {
+			return nil, fmt.Errorf("Namespace %q for %s %q is not managed", o.GetNamespace(), o.GetKind(), o.GetName())
+		}
+	}
 
 	managedObjs := make(map[kube.ResourceKey]*unstructured.Unstructured)
 	// iterate all objects in live state cache to find ones associated with app

--- a/pkg/cache/cluster.go
+++ b/pkg/cache/cluster.go
@@ -665,8 +665,8 @@ func (c *clusterCache) managesNamespace(namespace string) bool {
 	if len(c.namespaces) == 0 {
 		return true
 	}
-	if len(namespace) == 0 {
-		return true
+	if namespace == "" {
+		return false
 	}
 	for _, ns := range c.namespaces {
 		if ns == namespace {
@@ -685,6 +685,9 @@ func (c *clusterCache) GetManagedLiveObjs(targetObjs []*unstructured.Unstructure
 
 	for _, o := range targetObjs {
 		if !c.managesNamespace(o.GetNamespace()) {
+			if o.GetNamespace() == "" {
+				return nil, fmt.Errorf("Cluster level %s %q can not be managed when in namespaced mode", o.GetKind(), o.GetName())
+			}
 			return nil, fmt.Errorf("Namespace %q for %s %q is not managed", o.GetNamespace(), o.GetKind(), o.GetName())
 		}
 	}

--- a/pkg/cache/cluster_test.go
+++ b/pkg/cache/cluster_test.go
@@ -372,6 +372,88 @@ metadata:
 	})
 }
 
+func TestGetManagedLiveObjsAllNamespaces(t *testing.T) {
+	cluster := newCluster(testPod, testRS, testDeploy)
+	cluster.Invalidate(SetPopulateResourceInfoHandler(func(un *unstructured.Unstructured, isRoot bool) (info interface{}, cacheManifest bool) {
+		return nil, true
+	}))
+	cluster.namespaces = nil
+
+	err := cluster.EnsureSynced()
+	assert.Nil(t, err)
+
+	targetDeploy := strToUnstructured(`
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: helm-guestbook
+  namespace: production
+  labels:
+    app: helm-guestbook`)
+
+	managedObjs, err := cluster.GetManagedLiveObjs([]*unstructured.Unstructured{targetDeploy}, func(r *Resource) bool {
+		return len(r.OwnerRefs) == 0
+	})
+	assert.Nil(t, err)
+	assert.Equal(t, managedObjs, map[kube.ResourceKey]*unstructured.Unstructured{
+		kube.NewResourceKey("apps", "Deployment", "default", "helm-guestbook"): testDeploy,
+	})
+}
+
+func TestGetManagedLiveObjsValidNamespace(t *testing.T) {
+	cluster := newCluster(testPod, testRS, testDeploy)
+	cluster.Invalidate(SetPopulateResourceInfoHandler(func(un *unstructured.Unstructured, isRoot bool) (info interface{}, cacheManifest bool) {
+		return nil, true
+	}))
+	cluster.namespaces = []string{"default", "production"}
+
+	err := cluster.EnsureSynced()
+	assert.Nil(t, err)
+
+	targetDeploy := strToUnstructured(`
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: helm-guestbook
+  namespace: production
+  labels:
+    app: helm-guestbook`)
+
+	managedObjs, err := cluster.GetManagedLiveObjs([]*unstructured.Unstructured{targetDeploy}, func(r *Resource) bool {
+		return len(r.OwnerRefs) == 0
+	})
+	assert.Nil(t, err)
+	assert.Equal(t, managedObjs, map[kube.ResourceKey]*unstructured.Unstructured{
+		kube.NewResourceKey("apps", "Deployment", "default", "helm-guestbook"): testDeploy,
+	})
+}
+
+func TestGetManagedLiveObjsInvalidNamespace(t *testing.T) {
+	cluster := newCluster(testPod, testRS, testDeploy)
+	cluster.Invalidate(SetPopulateResourceInfoHandler(func(un *unstructured.Unstructured, isRoot bool) (info interface{}, cacheManifest bool) {
+		return nil, true
+	}))
+	cluster.namespaces = []string{"default", "develop"}
+
+	err := cluster.EnsureSynced()
+	assert.Nil(t, err)
+
+	targetDeploy := strToUnstructured(`
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: helm-guestbook
+  namespace: production
+  labels:
+    app: helm-guestbook`)
+
+	managedObjs, err := cluster.GetManagedLiveObjs([]*unstructured.Unstructured{targetDeploy}, func(r *Resource) bool {
+		return len(r.OwnerRefs) == 0
+	})
+	assert.Nil(t, managedObjs)
+	assert.Equal(t, "Namespace \"production\" for Deployment \"helm-guestbook\" is not managed", err.Error())
+}
+
 func TestChildDeletedEvent(t *testing.T) {
 	cluster := newCluster(testPod, testRS, testDeploy)
 	err := cluster.EnsureSynced()


### PR DESCRIPTION
Signed-off-by: John Pitman <jpitman@redhat.com>

Related to https://github.com/argoproj/argo-cd/issues/4329

Return an error from `clusterCache.GetManagedLiveObjs` if we find a target object in a namespace that is not managed by the cluster.