### PR TITLE
fix: avoid memory and events spike after forcefully refreshing api cache

### DIFF
--- a/pkg/cache/cluster_test.go
+++ b/pkg/cache/cluster_test.go
@@ -569,7 +569,7 @@ func TestWatchCacheUpdated(t *testing.T) {
 	podGroupKind := testPod.GroupVersionKind().GroupKind()
 
 	cluster.lock.Lock()
-	cluster.replaceResourceCache(podGroupKind, []unstructured.Unstructured{*updated, *added}, "")
+	cluster.replaceResourceCache(podGroupKind, []*Resource{cluster.newResource(updated), cluster.newResource(added)}, "")
 
 	_, ok := cluster.resources[kube.GetResourceKey(removed)]
 	assert.False(t, ok)


### PR DESCRIPTION
The controller cache incorrectly notifies consumer every 10 minutes when re-syncs the K8S API. The PR fixes that issue