### PR TITLE
fix: Child apps should not affect parent app's health by default

### DIFF
--- a/pkg/health/health.go
+++ b/pkg/health/health.go
@@ -115,8 +115,6 @@ func GetResourceHealth(obj *unstructured.Unstructured, healthOverride HealthOver
 		}
 	case "argoproj.io":
 		switch gvk.Kind {
-		case "Application":
-			health = getApplicationHealth(obj)
 		case "Workflow":
 			health, err = getArgoWorkflowHealth(obj)
 		}
@@ -255,12 +253,6 @@ func getDeploymentHealth(obj *unstructured.Unstructured) (*HealthStatus, error) 
 func init() {
 	_ = apiregistrationv1.SchemeBuilder.AddToScheme(scheme.Scheme)
 	_ = apiregistrationv1beta1.SchemeBuilder.AddToScheme(scheme.Scheme)
-}
-
-func getApplicationHealth(obj *unstructured.Unstructured) *HealthStatus {
-	status, _, _ := unstructured.NestedString(obj.Object, "status", "health", "status")
-	message, _, _ := unstructured.NestedString(obj.Object, "status", "health", "message")
-	return &HealthStatus{Status: HealthStatusCode(status), Message: message}
 }
 
 func getDaemonSetHealth(obj *unstructured.Unstructured) (*HealthStatus, error) {

--- a/pkg/health/health_test.go
+++ b/pkg/health/health_test.go
@@ -91,8 +91,8 @@ func TestPod(t *testing.T) {
 }
 
 func TestApplication(t *testing.T) {
-	assertAppHealth(t, "./testdata/application-healthy.yaml", HealthStatusHealthy)
-	assertAppHealth(t, "./testdata/application-degraded.yaml", HealthStatusDegraded)
+	assert.Nil(t, getHealthStatus("./testdata/application-healthy.yaml", t))
+	assert.Nil(t, getHealthStatus("./testdata/application-degraded.yaml", t))
 }
 
 func TestAPIService(t *testing.T) {


### PR DESCRIPTION
Signed-off-by: Keith Chong <kykchong@redhat.com>

This fix is for ArgoCD issue: https://github.com/argoproj/argo-cd/issues/3781

Remove health assessment check for applications