### PR TITLE
Set TLSServerName in NewKubeConfig

### DIFF
--- a/pkg/utils/kube/kube.go
+++ b/pkg/utils/kube/kube.go
@@ -222,6 +222,7 @@ func NewKubeConfig(restConfig *rest.Config, namespace string) *clientcmdapi.Conf
 		Clusters: map[string]*clientcmdapi.Cluster{
 			restConfig.Host: {
 				Server:                   restConfig.Host,
+				TLSServerName:            restConfig.TLSClientConfig.ServerName,
 				InsecureSkipTLSVerify:    restConfig.TLSClientConfig.Insecure,
 				CertificateAuthority:     restConfig.TLSClientConfig.CAFile,
 				CertificateAuthorityData: restConfig.TLSClientConfig.CAData,

--- a/pkg/utils/kube/kube_test.go
+++ b/pkg/utils/kube/kube_test.go
@@ -90,6 +90,28 @@ func TestInClusterKubeConfig(t *testing.T) {
 	assert.Empty(t, kubeConfig.AuthInfos[kubeConfig.CurrentContext].TokenFile)
 }
 
+func TestNewKubeConfig_TLSServerName(t *testing.T) {
+	const (
+		host          = "something.test"
+		tlsServerName = "something.else.test"
+	)
+
+	restConfig := &rest.Config{
+		Host: host,
+	}
+	kubeConfig := NewKubeConfig(restConfig, "")
+	assert.Empty(t, kubeConfig.Clusters[host].TLSServerName)
+
+	restConfig = &rest.Config{
+		Host: host,
+		TLSClientConfig: rest.TLSClientConfig{
+			ServerName: tlsServerName,
+		},
+	}
+	kubeConfig = NewKubeConfig(restConfig, "")
+	assert.Equal(t, tlsServerName, kubeConfig.Clusters[host].TLSServerName)
+}
+
 func TestGetDeploymentReplicas(t *testing.T) {
 	manifest := []byte(`
 apiVersion: apps/v1


### PR DESCRIPTION
Update NewKubeConfig to copy the TLSClientConfig.ServerName to the
TLSServerName field of the cluster. This will allow for connecting
to an API server behind a load balancer when the load balancer DNS
name or IP does not match the API server TLS certificate.