### PR TITLE
feat: Namespace/CRD creation should happen before PreSync phase

### DIFF
--- a/pkg/sync/sync_context.go
+++ b/pkg/sync/sync_context.go
@@ -723,20 +723,27 @@ func (sc *syncContext) targetObjs() []*unstructured.Unstructured {
 	return objs
 }
 
+func isCRDOfGroupKind(group string, kind string, obj *unstructured.Unstructured) bool {
+	if kube.IsCRD(obj) {
+		crdGroup, ok, err := unstructured.NestedString(obj.Object, "spec", "group")
+		if err != nil || !ok {
+			return false
+		}
+		crdKind, ok, err := unstructured.NestedString(obj.Object, "spec", "names", "kind")
+		if err != nil || !ok {
+			return false
+		}
+		if group == crdGroup && crdKind == kind {
+			return true
+		}
+	}
+	return false
+}
+
 func (sc *syncContext) hasCRDOfGroupKind(group string, kind string) bool {
 	for _, obj := range sc.targetObjs() {
-		if kube.IsCRD(obj) {
-			crdGroup, ok, err := unstructured.NestedString(obj.Object, "spec", "group")
-			if err != nil || !ok {
-				continue
-			}
-			crdKind, ok, err := unstructured.NestedString(obj.Object, "spec", "names", "kind")
-			if err != nil || !ok {
-				continue
-			}
-			if group == crdGroup && crdKind == kind {
-				return true
-			}
+		if isCRDOfGroupKind(group, kind, obj) {
+			return true
 		}
 	}
 	return false

--- a/pkg/sync/sync_task.go
+++ b/pkg/sync/sync_task.go
@@ -25,6 +25,22 @@ type syncTask struct {
 	message        string
 }
 
+// isDependsOn returns true if given task depends on current task and should be executed after
+func (t *syncTask) isDependsOn(other *syncTask) bool {
+	otherObj := other.obj()
+	thisGVK := t.obj().GroupVersionKind()
+	otherGVK := otherObj.GroupVersionKind()
+
+	if isCRDOfGroupKind(thisGVK.Group, thisGVK.Kind, otherObj) {
+		return true
+	}
+
+	if otherGVK.Group == "" && otherGVK.Kind == kube.NamespaceKind && otherObj.GetName() == t.obj().GetNamespace() {
+		return true
+	}
+	return false
+}
+
 func ternary(val bool, a, b string) string {
 	if val {
 		return a

--- a/pkg/sync/sync_tasks.go
+++ b/pkg/sync/sync_tasks.go
@@ -74,6 +74,12 @@ func (s syncTasks) Less(i, j int) bool {
 	tA := s[i]
 	tB := s[j]
 
+	if tA.isDependsOn(tB) {
+		return false
+	} else if tB.isDependsOn(tA) {
+		return true
+	}
+
 	d := syncPhaseOrder[tA.phase] - syncPhaseOrder[tB.phase]
 	if d != 0 {
 		return d < 0


### PR DESCRIPTION
PR changes sync tasks sorting so that CRD and Namespace always created before matching CRs or objects in the same namespace.

Closes https://github.com/argoproj/argo-cd/issues/4354