### PR TITLE
fix: Data race between gitops-engine's pkg/cache/cluster.go and itself, on Argo CD startup (#4627)

### DIFF
--- a/pkg/cache/settings.go
+++ b/pkg/cache/settings.go
@@ -93,7 +93,10 @@ func SetListSemaphore(listSemaphore WeightedSemaphore) UpdateSettingsFunc {
 // SetResyncTimeout updates cluster re-sync timeout
 func SetResyncTimeout(timeout time.Duration) UpdateSettingsFunc {
 	return func(cache *clusterCache) {
-		cache.resyncTimeout = timeout
+		cache.syncStatus.lock.Lock()
+		defer cache.syncStatus.lock.Unlock()
+
+		cache.syncStatus.resyncTimeout = timeout
 	}
 }
 

--- a/pkg/cache/settings_test.go
+++ b/pkg/cache/settings_test.go
@@ -39,10 +39,10 @@ func TestSetNamespaces(t *testing.T) {
 
 func TestSetResyncTimeout(t *testing.T) {
 	cache := NewClusterCache(&rest.Config{})
-	assert.Equal(t, clusterResyncTimeout, cache.resyncTimeout)
+	assert.Equal(t, clusterResyncTimeout, cache.syncStatus.resyncTimeout)
 
 	timeout := 1 * time.Hour
 	cache.Invalidate(SetResyncTimeout(timeout))
 
-	assert.Equal(t, timeout, cache.resyncTimeout)
+	assert.Equal(t, timeout, cache.syncStatus.resyncTimeout)
 }


### PR DESCRIPTION

The fix is straightforward, as far as these things go: 
- Introduce a new lock, `clusterCacheSync.lock` which is only used for accessing the `syncStatus` fields of the cluster cache.
- Move fields into a `clusterCacheSync` struct which is managed by that lock
- This new lock is much cheaper to acquire than the cluster lock, since it does not block on the same heavyweight operations which use the cluster lock (with the one pre-existing exception of `EnsureSynced`'s resync operation)
- Add lock acquisition to code that uses `syncStatus`
- Add comment describing rules for acquiring `syncStatus` so that we don't deadlock.

**Parent issue**:
https://github.com/argoproj/argo-cd/issues/4627

