### PR TITLE
feat: introduce SyncWaveHook callbacks which are invoked after applying each sync wave

### DIFF
--- a/pkg/diff/diff.go
+++ b/pkg/diff/diff.go
@@ -83,7 +83,7 @@ func Diff(config, live *unstructured.Unstructured, opts ...Option) (*DiffResult,
 			if err == nil {
 				return dr, nil
 			}
-			o.log.V(1).Info("three-way diff calculation failed: %v. Falling back to two-way diff", err)
+			o.log.V(1).Info(fmt.Sprintf("three-way diff calculation failed: %v. Falling back to two-way diff", err))
 		}
 	}
 	return TwoWayDiff(config, live)

--- a/pkg/sync/common/types.go
+++ b/pkg/sync/common/types.go
@@ -29,6 +29,11 @@ type PermissionValidator func(un *unstructured.Unstructured, res *metav1.APIReso
 
 type SyncPhase string
 
+// SyncWaveHook is a callback function which will be invoked after each sync wave is successfully
+// applied during a sync operation. The callback indicates which phase and wave it had just
+// executed, and whether or not that wave was the final one.
+type SyncWaveHook func(phase SyncPhase, wave int, final bool) error
+
 const (
 	SyncPhasePreSync  = "PreSync"
 	SyncPhaseSync     = "Sync"

--- a/pkg/sync/sync_context.go
+++ b/pkg/sync/sync_context.go
@@ -414,8 +414,10 @@ func (sc *syncContext) Sync() {
 	if sc.syncWaveHook != nil && runState != failed {
 		err := sc.syncWaveHook(phase, wave, finalWave)
 		if err != nil {
+			sc.deleteHooks(hooksPendingDeletionFailed)
 			sc.setOperationPhase(common.OperationFailed, fmt.Sprintf("SyncWaveHook failed: %v", err))
-			runState = failed
+			sc.log.Error(err, "SyncWaveHook failed")
+			return
 		}
 	}
 

--- a/pkg/sync/sync_context.go
+++ b/pkg/sync/sync_context.go
@@ -135,6 +135,13 @@ func WithLogr(log logr.Logger) SyncOpt {
 	}
 }
 
+// WithSyncWaveHook sets a callback that is invoked after application of every wave
+func WithSyncWaveHook(syncWaveHook common.SyncWaveHook) SyncOpt {
+	return func(ctx *syncContext) {
+		ctx.syncWaveHook = syncWaveHook
+	}
+}
+
 //  NewSyncContext creates new instance of a SyncContext
 func NewSyncContext(
 	revision string,
@@ -261,6 +268,8 @@ type syncContext struct {
 
 	createNamespace   bool
 	namespaceModifier func(*unstructured.Unstructured) bool
+
+	syncWaveHook common.SyncWaveHook
 }
 
 func (sc *syncContext) setRunningPhase(tasks []*syncTask, isPendingDeletion bool) {
@@ -387,6 +396,7 @@ func (sc *syncContext) Sync() {
 	// remove any tasks not in this wave
 	phase := tasks.phase()
 	wave := tasks.wave()
+	finalWave := phase == tasks.lastPhase() && wave == tasks.lastWave()
 
 	// if it is the last phase/wave and the only remaining tasks are non-hooks, the we are successful
 	// EVEN if those objects subsequently degraded
@@ -400,6 +410,15 @@ func (sc *syncContext) Sync() {
 
 	sc.log.WithValues("tasks", tasks).V(1).Info("Wet-run")
 	runState := sc.runTasks(tasks, false)
+
+	if sc.syncWaveHook != nil && runState != failed {
+		err := sc.syncWaveHook(phase, wave, finalWave)
+		if err != nil {
+			sc.setOperationPhase(common.OperationFailed, fmt.Sprintf("SyncWaveHook failed: %v", err))
+			runState = failed
+		}
+	}
+
 	switch runState {
 	case failed:
 		sc.deleteHooks(hooksPendingDeletionFailed)
@@ -787,7 +806,7 @@ func (sc *syncContext) Terminate() {
 				sc.setResourceResult(task, "", common.OperationFailed, fmt.Sprintf("Failed to delete: %v", err))
 				terminateSuccessful = false
 			} else {
-				sc.setResourceResult(task, "", common.OperationSucceeded, fmt.Sprintf("Deleted"))
+				sc.setResourceResult(task, "", common.OperationSucceeded, "Deleted")
 			}
 		} else {
 			sc.setResourceResult(task, "", phase, msg)

--- a/pkg/sync/sync_context_test.go
+++ b/pkg/sync/sync_context_test.go
@@ -5,12 +5,6 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/argoproj/gitops-engine/pkg/health"
-	synccommon "github.com/argoproj/gitops-engine/pkg/sync/common"
-	"github.com/argoproj/gitops-engine/pkg/utils/kube"
-	"github.com/argoproj/gitops-engine/pkg/utils/kube/kubetest"
-	. "github.com/argoproj/gitops-engine/pkg/utils/testing"
-	testingutils "github.com/argoproj/gitops-engine/pkg/utils/testing"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -21,6 +15,13 @@ import (
 	"k8s.io/client-go/rest"
 	testcore "k8s.io/client-go/testing"
 	"k8s.io/klog/v2/klogr"
+
+	"github.com/argoproj/gitops-engine/pkg/health"
+	synccommon "github.com/argoproj/gitops-engine/pkg/sync/common"
+	"github.com/argoproj/gitops-engine/pkg/utils/kube"
+	"github.com/argoproj/gitops-engine/pkg/utils/kube/kubetest"
+	. "github.com/argoproj/gitops-engine/pkg/utils/testing"
+	testingutils "github.com/argoproj/gitops-engine/pkg/utils/testing"
 )
 
 func newTestSyncCtx(opts ...SyncOpt) *syncContext {
@@ -893,4 +894,75 @@ func Test_setRunningPhase_pendingDeletion(t *testing.T) {
 	sc.setRunningPhase([]*syncTask{{targetObj: NewPod()}, {targetObj: NewPod()}, {targetObj: NewPod()}}, true)
 
 	assert.Equal(t, "waiting for deletion of /Pod/my-pod and 2 more resources", sc.message)
+}
+
+func TestSyncWaveHook(t *testing.T) {
+	syncCtx := newTestSyncCtx(WithOperationSettings(false, false, false, false))
+	pod1 := NewPod()
+	pod1.SetName("pod-1")
+	pod1.SetAnnotations(map[string]string{synccommon.AnnotationSyncWave: "-1"})
+	pod2 := NewPod()
+	pod2.SetName("pod-2")
+	pod3 := NewPod()
+	pod3.SetName("pod-3")
+	pod3.SetAnnotations(map[string]string{synccommon.AnnotationKeyHook: "PostSync"})
+
+	syncCtx.resources = groupResources(ReconciliationResult{
+		Live:   []*unstructured.Unstructured{nil, nil},
+		Target: []*unstructured.Unstructured{pod1, pod2},
+	})
+	syncCtx.hooks = []*unstructured.Unstructured{pod3}
+
+	called := false
+	syncCtx.syncWaveHook = func(phase synccommon.SyncPhase, wave int, final bool) error {
+		called = true
+		assert.Equal(t, synccommon.SyncPhaseSync, string(phase))
+		assert.Equal(t, -1, wave)
+		assert.False(t, final)
+		return nil
+	}
+	syncCtx.Sync()
+	assert.True(t, called)
+
+	// call sync again, it should not invoke the SyncWaveHook callback since we only should be
+	// doing this after an apply, and not every reconciliation
+	called = false
+	syncCtx.syncWaveHook = func(phase synccommon.SyncPhase, wave int, final bool) error {
+		called = true
+		return nil
+	}
+	syncCtx.Sync()
+	assert.False(t, called)
+
+	// complete wave -1, then call Sync again. Verify we invoke another SyncWaveHook call after applying wave 0
+	_, _, results := syncCtx.GetState()
+	pod1Res := results[0]
+	pod1Res.HookPhase = synccommon.OperationSucceeded
+	syncCtx.syncRes[resourceResultKey(pod1Res.ResourceKey, synccommon.SyncPhaseSync)] = pod1Res
+	called = false
+	syncCtx.syncWaveHook = func(phase synccommon.SyncPhase, wave int, final bool) error {
+		called = true
+		assert.Equal(t, synccommon.SyncPhaseSync, string(phase))
+		assert.Equal(t, 0, wave)
+		assert.False(t, final)
+		return nil
+	}
+	syncCtx.Sync()
+	assert.True(t, called)
+
+	// complete wave 0. after applying PostSync, we should perform callback and final should be set true
+	_, _, results = syncCtx.GetState()
+	pod2Res := results[1]
+	pod2Res.HookPhase = synccommon.OperationSucceeded
+	syncCtx.syncRes[resourceResultKey(pod2Res.ResourceKey, synccommon.SyncPhaseSync)] = pod2Res
+	called = false
+	syncCtx.syncWaveHook = func(phase synccommon.SyncPhase, wave int, final bool) error {
+		called = true
+		assert.Equal(t, synccommon.SyncPhasePostSync, string(phase))
+		assert.Equal(t, 0, wave)
+		assert.True(t, final)
+		return nil
+	}
+	syncCtx.Sync()
+	assert.True(t, called)
 }

--- a/pkg/utils/kube/kube.go
+++ b/pkg/utils/kube/kube.go
@@ -372,17 +372,17 @@ func GetDeploymentReplicas(u *unstructured.Unstructured) *int64 {
 // RetryUntilSucceed keep retrying given action with specified interval until action succeed or specified context is done.
 func RetryUntilSucceed(ctx context.Context, interval time.Duration, desc string, log logr.Logger, action func() error) {
 	pollErr := wait.PollImmediateUntil(interval, func() (bool /*done*/, error) {
-		log.V(1).Info("Start %s", desc)
+		log.V(1).Info(fmt.Sprintf("Start %s", desc))
 		err := action()
 		if err == nil {
-			log.V(1).Info("Completed %s", desc)
+			log.V(1).Info(fmt.Sprintf("Completed %s", desc))
 			return true, nil
 		}
-		log.V(1).Info("Failed to %s: %+v, retrying in %v", desc, err, interval)
+		log.V(1).Info(fmt.Sprintf("Failed to %s: %+v, retrying in %v", desc, err, interval))
 		return false, nil
 	}, ctx.Done())
 	if pollErr != nil {
 		// The only error that can happen here is wait.ErrWaitTimeout if ctx is done.
-		log.V(1).Info("Stop retrying %s", desc)
+		log.V(1).Info(fmt.Sprintf("Stop retrying %s", desc))
 	}
 }


### PR DESCRIPTION
This is groundwork for fixing https://github.com/argoproj/argo-cd/issues/4669. It introduces a SyncWaveHook callback function, which is invoked after successfully applying each sync wave. Argo CD will leverage this by sleeping for a few seconds between each wave.

Also this fixes some logging issues after switching to the new logr.