### PR TITLE
fix: WithInitialState should require start time to support generateName hooks properly

### DIFF
--- a/pkg/sync/sync_context.go
+++ b/pkg/sync/sync_context.go
@@ -71,11 +71,12 @@ func WithHealthOverride(override health.HealthOverride) SyncOpt {
 }
 
 // WithInitialState sets sync operation initial state
-func WithInitialState(phase common.OperationPhase, message string, results []common.ResourceSyncResult) SyncOpt {
+func WithInitialState(phase common.OperationPhase, message string, results []common.ResourceSyncResult, startedAt metav1.Time) SyncOpt {
 	return func(ctx *syncContext) {
 		ctx.phase = phase
 		ctx.message = message
 		ctx.syncRes = map[string]common.ResourceSyncResult{}
+		ctx.startedAt = startedAt.Time
 		for i := range results {
 			ctx.syncRes[resourceResultKey(results[i].ResourceKey, results[i].SyncPhase)] = results[i]
 		}

--- a/pkg/sync/sync_context_test.go
+++ b/pkg/sync/sync_context_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -708,7 +709,9 @@ func TestRunSync_HooksNotDeletedIfPhaseNotCompleted(t *testing.T) {
 			ResourceKey: kube.GetResourceKey(inProgressHook),
 			HookPhase:   synccommon.OperationRunning,
 			SyncPhase:   synccommon.SyncPhasePreSync,
-		}}))
+		}},
+			metav1.Now(),
+		))
 	fakeDynamicClient := fake.NewSimpleDynamicClient(runtime.NewScheme())
 	syncCtx.dynamicIf = fakeDynamicClient
 	deletedCount := 0
@@ -752,7 +755,9 @@ func TestRunSync_HooksDeletedAfterPhaseCompleted(t *testing.T) {
 			ResourceKey: kube.GetResourceKey(completedHook2),
 			HookPhase:   synccommon.OperationSucceeded,
 			SyncPhase:   synccommon.SyncPhasePreSync,
-		}}))
+		}},
+			metav1.Now(),
+		))
 	fakeDynamicClient := fake.NewSimpleDynamicClient(runtime.NewScheme())
 	syncCtx.dynamicIf = fakeDynamicClient
 	deletedCount := 0
@@ -796,7 +801,9 @@ func TestRunSync_HooksDeletedAfterPhaseCompletedFailed(t *testing.T) {
 			ResourceKey: kube.GetResourceKey(completedHook2),
 			HookPhase:   synccommon.OperationFailed,
 			SyncPhase:   synccommon.SyncPhaseSync,
-		}}))
+		}},
+			metav1.Now(),
+		))
 	fakeDynamicClient := fake.NewSimpleDynamicClient(runtime.NewScheme())
 	syncCtx.dynamicIf = fakeDynamicClient
 	deletedCount := 0


### PR DESCRIPTION
This is a follow up to https://github.com/argoproj/gitops-engine/pull/180.

When resuming a sync operation, we need startTime to be stable from previous reconciliation, because startTime is used in sync hooks which use generateName(). Without this fix, we get into a continuous loop where we create infinite number of hooks when they use generateName.
