### PR TITLE
feat: prune last

### DIFF
--- a/pkg/sync/common/types.go
+++ b/pkg/sync/common/types.go
@@ -23,6 +23,8 @@ const (
 	SyncOptionDisablePrune = "Prune=false"
 	// Sync option that disables resource validation
 	SyncOptionsDisableValidation = "Validate=false"
+	// Sync option that enables pruneLast
+	SyncOptionPruneLast = "PruneLast=true"
 )
 
 type PermissionValidator func(un *unstructured.Unstructured, res *metav1.APIResource) error


### PR DESCRIPTION
fixes: #5080.
If sync option has `PruneLast=true`, or individual resource has annotation `argocd.argoproj.io/sync-options: PruneLast=true`, these prune tasks get assigned with a new sync wave.

the new sync wave is the last sync wave of non-prune tasks which is in sync phase + 1, so that these resources will be pruned after all sync phase resources are synced and healthy.