### PR TITLE
feat: selective sync

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .vscode
 .idea
 coverage.out
+vendor/


### PR DESCRIPTION
Signed-off-by: kshamajain99 <kshamajain99@gmail.com>

issue: https://github.com/argoproj/argo-cd/issues/3877
argo-cd PR: https://github.com/argoproj/argo-cd/pull/5347

This feature applies only out-of-sync resources when `ApplyOutOfSync=true` option is provided by user. 

#### Test performed:

Scenario: For an application with 10 deployments and 1 svc, deleting svc and syncing entire application (performing same action)

With `ApplyOutOfSync=true` enabled
```
INFO[0040] sync/terminate complete              application=guestbook duration=507.61639ms syncId=00001-NPWVT
```

Without `ApplyOutOfSync=true` enabled
```
INFO[0114] sync/terminate complete              application=guestbook duration=1.983608856s syncId=00002-orWNj
```