### PR TITLE
fix: when there are namespace resources, sync them first.

### DIFF
--- a/pkg/sync/sync_context.go
+++ b/pkg/sync/sync_context.go
@@ -461,7 +461,7 @@ func (sc *syncContext) Sync() {
 	// EVEN if those objects subsequently degraded
 	// This handles the common case where neither hooks or waves are used and a sync equates to simply an (asynchronous) kubectl apply of manifests, which succeeds immediately.
 	remainingTasks := tasks[len(tasksTop):]
-	for _, task := range tasks {
+	for _, task := range tasksTop {
 		if task.isHook() {
 			remainingTasks = append(remainingTasks, task)
 		}

--- a/pkg/sync/sync_context.go
+++ b/pkg/sync/sync_context.go
@@ -444,6 +444,7 @@ func (sc *syncContext) Sync() {
 	// remove any tasks not in this wave
 	phase := tasks.phase()
 	wave := tasks.wave()
+	finalWave := phase == tasks.lastPhase() && wave == tasks.lastWave()
 
 	sc.log.WithValues("phase", phase, "wave", wave, "tasks", tasks, "syncFailTasks", syncFailTasks).V(1).Info("Filtering tasks in correct phase and wave")
 	//Only get the top few tasks which match phase and wave
@@ -465,8 +466,6 @@ func (sc *syncContext) Sync() {
 			remainingTasks = append(remainingTasks, task)
 		}
 	}
-
-	finalWave := isFinalWave(remainingTasks)
 
 	tasks = tasksTop
 
@@ -502,19 +501,6 @@ func (sc *syncContext) Sync() {
 			return task.deleteOnPhaseCompletion()
 		}), true)
 	}
-}
-
-func isFinalWave(remainingTasks []*syncTask) bool {
-	if len(remainingTasks) == 0 {
-		return true
-	}
-
-	for _, task := range remainingTasks {
-		if !task.isHook() {
-			return false
-		}
-	}
-	return true
 }
 
 func (sc *syncContext) deleteHooks(hooksPendingDeletion syncTasks) {

--- a/pkg/sync/sync_task.go
+++ b/pkg/sync/sync_task.go
@@ -35,7 +35,7 @@ func (t *syncTask) isDependsOn(other *syncTask) bool {
 		return true
 	}
 
-	if otherGVK.Group == "" && otherGVK.Kind == kube.NamespaceKind && otherObj.GetName() == t.obj().GetNamespace() {
+	if otherGVK.Group == "" && otherGVK.Kind == kube.NamespaceKind {
 		return true
 	}
 	return false

--- a/pkg/sync/sync_tasks_test.go
+++ b/pkg/sync/sync_tasks_test.go
@@ -398,11 +398,24 @@ func TestSyncTasksSort_NamespaceAndObjectInNamespace(t *testing.T) {
 }
 
 func TestSyncTasksSort_NamespaceAndObjectNotInNamespace(t *testing.T) {
-	deployment := &syncTask{
+	preSyncCRB := &syncTask{
 		phase: common.SyncPhasePreSync,
 		targetObj: &unstructured.Unstructured{
 			Object: map[string]interface{}{
 				"kind": "ClusterRoleBinding",
+				"metadata": map[string]interface{}{
+					"helm.sh/hook": "pre-install,pre-upgrade",
+				},
+			},
+		}}
+	preSyncSA := &syncTask{
+		phase: common.SyncPhasePreSync,
+		targetObj: &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"kind": "ServiceAccount",
+				"metadata": map[string]interface{}{
+					"helm.sh/hook": "pre-install,pre-upgrade",
+				},
 			},
 		}}
 	namespace := &syncTask{
@@ -416,10 +429,10 @@ func TestSyncTasksSort_NamespaceAndObjectNotInNamespace(t *testing.T) {
 		},
 	}
 
-	unsorted := syncTasks{deployment, namespace}
+	unsorted := syncTasks{preSyncCRB, preSyncSA, namespace}
 	sort.Sort(unsorted)
 
-	assert.Equal(t, syncTasks{namespace, deployment}, unsorted)
+	assert.Equal(t, syncTasks{namespace, preSyncSA, preSyncCRB}, unsorted)
 }
 
 func TestSyncTasksSort_CRDAndCR(t *testing.T) {

--- a/pkg/sync/sync_tasks_test.go
+++ b/pkg/sync/sync_tasks_test.go
@@ -397,6 +397,31 @@ func TestSyncTasksSort_NamespaceAndObjectInNamespace(t *testing.T) {
 	assert.Equal(t, syncTasks{namespace, deployment}, unsorted)
 }
 
+func TestSyncTasksSort_NamespaceAndObjectNotInNamespace(t *testing.T) {
+	deployment := &syncTask{
+		phase: common.SyncPhasePreSync,
+		targetObj: &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"kind": "ClusterRoleBinding",
+			},
+		}}
+	namespace := &syncTask{
+		targetObj: &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"kind": "Namespace",
+				"metadata": map[string]interface{}{
+					"name": "myNamespace",
+				},
+			},
+		},
+	}
+
+	unsorted := syncTasks{deployment, namespace}
+	sort.Sort(unsorted)
+
+	assert.Equal(t, syncTasks{namespace, deployment}, unsorted)
+}
+
 func TestSyncTasksSort_CRDAndCR(t *testing.T) {
 	crd := &syncTask{
 		phase: common.SyncPhasePreSync,


### PR DESCRIPTION
Signed-off-by: May Zhang <may_zhang@intuit.com>

When resources contain namespace resource, along with resource `ClusterRoleBinding` which is a PreSync hook, resource `ClusterRoleBinding` is synced prior to namespace resource. This is due to `ClusterRoleBinding` resource does not have namespace field specified. 

This PR is to fix when there are namespace resources, we should sync namespace resources first.