### PR TITLE
fix: Add additional healthy states for HPA

### DIFF
--- a/pkg/health/health_hpa.go
+++ b/pkg/health/health_hpa.go
@@ -144,6 +144,8 @@ func isHealthy(condition *hpaCondition) bool {
 	healthy_states := []hpaCondition{
 		{Type: "AbleToScale", Reason: "SucceededRescale"},
 		{Type: "ScalingLimited", Reason: "DesiredWithinRange"},
+		{Type: "ScalingLimited", Reason: "TooFewReplicas"},
+		{Type: "ScalingLimited", Reason: "TooManyReplicas"},
 	}
 	for _, healthy_state := range healthy_states {
 		if condition.Type == healthy_state.Type && condition.Reason == healthy_state.Reason {

--- a/pkg/health/health_test.go
+++ b/pkg/health/health_test.go
@@ -82,6 +82,7 @@ func TestHPA(t *testing.T) {
 	assertAppHealth(t, "./testdata/hpa-v2beta1-healthy.yaml", HealthStatusHealthy)
 	assertAppHealth(t, "./testdata/hpa-v1-degraded.yaml", HealthStatusDegraded)
 	assertAppHealth(t, "./testdata/hpa-v1-healthy.yaml", HealthStatusHealthy)
+	assertAppHealth(t, "./testdata/hpa-v1-healthy-toofew.yaml", HealthStatusHealthy)
 	assertAppHealth(t, "./testdata/hpa-v1-progressing.yaml", HealthStatusProgressing)
 	assertAppHealth(t, "./testdata/hpa-v1-progressing-with-no-annotations.yaml", HealthStatusProgressing)
 }

--- a/pkg/health/testdata/hpa-v1-healthy-toofew.yaml
+++ b/pkg/health/testdata/hpa-v1-healthy-toofew.yaml
@@ -1,0 +1,28 @@
+apiVersion: autoscaling/v1
+kind: HorizontalPodAutoscaler
+metadata:
+  annotations:
+    autoscaling.alpha.kubernetes.io/conditions: '[{"type":"AbleToScale","status":"True","lastTransitionTime":"2021-03-08T17:42:11Z","reason":"ReadyForNewScale","message":"recommended
+      size matches current size"},{"type":"ScalingActive","status":"True","lastTransitionTime":"2021-03-09T23:59:49Z","reason":"ValidMetricFound","message":"the
+      HPA was able to successfully calculate a replica count from memory resource
+      utilization (percentage of request)"},{"type":"ScalingLimited","status":"True","lastTransitionTime":"2021-03-10T10:02:12Z","reason":"TooFewReplicas","message":"the
+      desired replica count is less than the minimum replica count"}]'
+    autoscaling.alpha.kubernetes.io/current-metrics: '[{"type":"Resource","resource":{"name":"memory","currentAverageUtilization":2,"currentAverageValue":"3452928"}},{"type":"Resource","resource":{"name":"cpu","currentAverageUtilization":1,"currentAverageValue":"1m"}}]'
+  name: sample
+  namespace: default
+  resourceVersion: "41720063"
+  selfLink: /apis/autoscaling/v1/namespaces/default/horizontalpodautoscalers/sample
+  uid: cbe887e2-93d6-40de-8f03-7eb7e2d7f978
+spec:
+  maxReplicas: 10
+  minReplicas: 2
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: sample
+  targetCPUUtilizationPercentage: 80
+status:
+  currentCPUUtilizationPercentage: 1
+  currentReplicas: 2
+  desiredReplicas: 2
+  lastScaleTime: "2021-03-08T17:42:11Z"


### PR DESCRIPTION
In the case that you have a HPA with a minimum or maximum replica count set, and the metrics would indicate a need to scale beyond those, this is still an expected and healthy state.

I've got a Deployment & HPA, which doesn't have much load right now, but still has a minimum replicas set to 2 (for HA). This means Argo CD is currently constantly showing it as Progressing, which isn't correct.

Here I'm trying to add the additional healthy states I see.

I wonder though, is checking conditions correct, or should this be checking if the `Status` of the condition is True?
(e.g. is healthy == AbleToScale.Status == True && ScalingActive.Status == True)