### PR TITLE
feat: support replace strategy for CRD

### DIFF
--- a/pkg/utils/kube/kubetest/mock.go
+++ b/pkg/utils/kube/kubetest/mock.go
@@ -98,6 +98,15 @@ func (k *MockKubectlCmd) CreateResource(ctx context.Context, config *rest.Config
 	return obj, command.Err
 }
 
+func (k *MockKubectlCmd) UpdateResource(ctx context.Context, config *rest.Config, obj *unstructured.Unstructured, namespace string, dryRunStrategy cmdutil.DryRunStrategy) (*unstructured.Unstructured, error) {
+	k.SetLastResourceCommand(kube.GetResourceKey(obj), "update")
+	command, ok := k.Commands[obj.GetName()]
+	if !ok {
+		return obj, nil
+	}
+	return obj, command.Err
+}
+
 func (k *MockKubectlCmd) ApplyResource(ctx context.Context, config *rest.Config, obj *unstructured.Unstructured, namespace string, dryRunStrategy cmdutil.DryRunStrategy, force, validate bool) (string, error) {
 	k.SetLastValidate(validate)
 	k.SetLastResourceCommand(kube.GetResourceKey(obj), "apply")


### PR DESCRIPTION
Signed-off-by: Alexander Matyushentsev <AMatyushentsev@gmail.com>

Addresses issue reported in https://github.com/argoproj/argo-cd/issues/820 for CRDs. The sync should attempt to just update CRD spec if `Replace=true` sync option is specified. The update won't attempt to recreate CRD so it is safe and it is not trying to set `last-applied-configuration` annotation . 