### PR TITLE
fix: missing resource version in tests

### DIFF
--- a/pkg/cache/cluster_test.go
+++ b/pkg/cache/cluster_test.go
@@ -73,10 +73,11 @@ func newCluster(t *testing.T, objs ...runtime.Object) *clusterCache {
 	reactor := client.ReactionChain[0]
 	client.PrependReactor("list", "*", func(action testcore.Action) (handled bool, ret runtime.Object, err error) {
 		handled, ret, err = reactor.React(action)
-		// make sure list response have resource version
-		if list, ok := ret.(*unstructured.UnstructuredList); ok {
-			list.SetResourceVersion("123")
+		if err != nil || !handled {
+			return
 		}
+		// make sure list response have resource version
+		ret.(metav1.ListInterface).SetResourceVersion("123")
 		return
 	})
 


### PR DESCRIPTION
`FakeDynamicClient` returns typed lists (not unstructured lists) since Kubernetes 1.20. The type cast now handles that. It's a bug I introduced in #195, sorry about that.

Fixes #254.