### PR TITLE
refactor: cache cmdutil.Factory to improve synchronization performance

### DIFF
--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -84,10 +84,11 @@ func (e *gitOpsEngine) Sync(ctx context.Context,
 		return nil, err
 	}
 	opts = append(opts, sync.WithSkipHooks(!diffRes.Modified))
-	syncCtx, err := sync.NewSyncContext(revision, result, e.config, e.config, e.kubectl, namespace, opts...)
+	syncCtx, cleanup, err := sync.NewSyncContext(revision, result, e.config, e.config, e.kubectl, namespace, opts...)
 	if err != nil {
 		return nil, err
 	}
+	defer cleanup()
 
 	resUpdated := make(chan bool)
 	unsubscribe := e.cache.OnResourceUpdated(func(newRes *cache.Resource, oldRes *cache.Resource, namespaceResources map[kube.ResourceKey]*cache.Resource) {

--- a/pkg/utils/kube/ctl.go
+++ b/pkg/utils/kube/ctl.go
@@ -1,36 +1,21 @@
 package kube
 
 import (
-	"bytes"
 	"context"
-	"encoding/json"
-	"errors"
 	"fmt"
 	"io/ioutil"
-	"strings"
 
 	"github.com/go-logr/logr"
 	"golang.org/x/sync/errgroup"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/cli-runtime/pkg/genericclioptions"
-	"k8s.io/cli-runtime/pkg/printers"
-	"k8s.io/cli-runtime/pkg/resource"
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/dynamic"
-	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
-	"k8s.io/kubectl/pkg/cmd/apply"
-	"k8s.io/kubectl/pkg/cmd/auth"
-	"k8s.io/kubectl/pkg/cmd/replace"
-	cmdutil "k8s.io/kubectl/pkg/cmd/util"
-	"k8s.io/kubectl/pkg/scheme"
 
-	"github.com/argoproj/gitops-engine/pkg/diff"
-	"github.com/argoproj/gitops-engine/pkg/utils/io"
+	utils "github.com/argoproj/gitops-engine/pkg/utils/io"
 	"github.com/argoproj/gitops-engine/pkg/utils/tracing"
 )
 
@@ -39,10 +24,7 @@ type CleanupFunc func()
 type OnKubectlRunFunc func(command string) (CleanupFunc, error)
 
 type Kubectl interface {
-	ApplyResource(ctx context.Context, config *rest.Config, obj *unstructured.Unstructured, namespace string, dryRunStrategy cmdutil.DryRunStrategy, force, validate bool) (string, error)
-	ReplaceResource(ctx context.Context, config *rest.Config, obj *unstructured.Unstructured, namespace string, dryRunStrategy cmdutil.DryRunStrategy, force bool) (string, error)
-	CreateResource(ctx context.Context, config *rest.Config, obj *unstructured.Unstructured, namespace string, dryRunStrategy cmdutil.DryRunStrategy) (*unstructured.Unstructured, error)
-	UpdateResource(ctx context.Context, config *rest.Config, obj *unstructured.Unstructured, namespace string, dryRunStrategy cmdutil.DryRunStrategy) (*unstructured.Unstructured, error)
+	ManageResources(config *rest.Config) (ResourceOperations, func(), error)
 	ConvertToVersion(obj *unstructured.Unstructured, group, version string) (*unstructured.Unstructured, error)
 	DeleteResource(ctx context.Context, config *rest.Config, gvk schema.GroupVersionKind, name string, namespace string, deleteOptions metav1.DeleteOptions) error
 	GetResource(ctx context.Context, config *rest.Config, gvk schema.GroupVersionKind, name string, namespace string) (*unstructured.Unstructured, error)
@@ -219,382 +201,32 @@ func (k *KubectlCmd) DeleteResource(ctx context.Context, config *rest.Config, gv
 	return resourceIf.Delete(ctx, name, deleteOptions)
 }
 
-type commandExecutor func(config *rest.Config, f cmdutil.Factory, ioStreams genericclioptions.IOStreams, fileName string, namespace string, dryRunStrategy cmdutil.DryRunStrategy) error
-
-func (k *KubectlCmd) runResourceCommand(ctx context.Context, config *rest.Config, obj *unstructured.Unstructured, namespace string, dryRunStrategy cmdutil.DryRunStrategy, executor commandExecutor) (string, error) {
-	f, err := ioutil.TempFile(io.TempDir, "")
+func (k *KubectlCmd) ManageResources(config *rest.Config) (ResourceOperations, func(), error) {
+	f, err := ioutil.TempFile(utils.TempDir, "")
 	if err != nil {
-		return "", fmt.Errorf("Failed to generate temp file for kubeconfig: %v", err)
+		return nil, nil, fmt.Errorf("Failed to generate temp file for kubeconfig: %v", err)
 	}
 	_ = f.Close()
-	err = WriteKubeConfig(config, namespace, f.Name())
+	err = WriteKubeConfig(config, "", f.Name())
 	if err != nil {
-		return "", fmt.Errorf("Failed to write kubeconfig: %v", err)
+		return nil, nil, fmt.Errorf("Failed to write kubeconfig: %v", err)
 	}
-	defer io.DeleteFile(f.Name())
-	manifestBytes, err := json.Marshal(obj)
+	fact := kubeCmdFactory(f.Name(), "")
+	openAPISchema, err := fact.OpenAPISchema()
 	if err != nil {
-		return "", err
+		return nil, nil, err
 	}
-	manifestFile, err := ioutil.TempFile(io.TempDir, "")
-	if err != nil {
-		return "", fmt.Errorf("Failed to generate temp file for manifest: %v", err)
+	cleanup := func() {
+		utils.DeleteFile(f.Name())
 	}
-	if _, err = manifestFile.Write(manifestBytes); err != nil {
-		return "", fmt.Errorf("Failed to write manifest: %v", err)
-	}
-	if err = manifestFile.Close(); err != nil {
-		return "", fmt.Errorf("Failed to close manifest: %v", err)
-	}
-	defer io.DeleteFile(manifestFile.Name())
-
-	// log manifest
-	if k.Log.V(1).Enabled() {
-		var obj unstructured.Unstructured
-		err := json.Unmarshal(manifestBytes, &obj)
-		if err != nil {
-			return "", err
-		}
-		redacted, _, err := diff.HideSecretData(&obj, nil)
-		if err != nil {
-			return "", err
-		}
-		redactedBytes, err := json.Marshal(redacted)
-		if err != nil {
-			return "", err
-		}
-		k.Log.V(1).Info(string(redactedBytes))
-	}
-
-	var out []string
-	if obj.GetAPIVersion() == "rbac.authorization.k8s.io/v1" {
-		// If it is an RBAC resource, run `kubectl auth reconcile`. This is preferred over
-		// `kubectl apply`, which cannot tolerate changes in roleRef, which is an immutable field.
-		// See: https://github.com/kubernetes/kubernetes/issues/66353
-		// `auth reconcile` will delete and recreate the resource if necessary
-		outReconcile, err := func() (string, error) {
-			cleanup, err := k.processKubectlRun("auth")
-			if err != nil {
-				return "", err
-			}
-			defer cleanup()
-			return k.authReconcile(ctx, config, f.Name(), manifestFile.Name(), namespace, dryRunStrategy)
-		}()
-		if err != nil {
-			return "", err
-		}
-		out = append(out, outReconcile)
-		// We still want to fallthrough and run `kubectl apply` in order set the
-		// last-applied-configuration annotation in the object.
-	}
-
-	// Run kubectl apply
-	fact, ioStreams := kubeCmdFactory(f.Name(), namespace)
-	err = executor(config, fact, ioStreams, manifestFile.Name(), namespace, dryRunStrategy)
-	if err != nil {
-		return "", errors.New(cleanKubectlOutput(err.Error()))
-	}
-	if buf := strings.TrimSpace(ioStreams.Out.(*bytes.Buffer).String()); len(buf) > 0 {
-		out = append(out, buf)
-	}
-	if buf := strings.TrimSpace(ioStreams.ErrOut.(*bytes.Buffer).String()); len(buf) > 0 {
-		out = append(out, buf)
-	}
-	return strings.Join(out, ". "), nil
-}
-
-func kubeCmdFactory(kubeconfig, ns string) (cmdutil.Factory, genericclioptions.IOStreams) {
-	kubeConfigFlags := genericclioptions.NewConfigFlags(true)
-	if ns != "" {
-		kubeConfigFlags.Namespace = &ns
-	}
-	kubeConfigFlags.KubeConfig = &kubeconfig
-	matchVersionKubeConfigFlags := cmdutil.NewMatchVersionFlags(kubeConfigFlags)
-	f := cmdutil.NewFactory(matchVersionKubeConfigFlags)
-	ioStreams := genericclioptions.IOStreams{
-		In:     &bytes.Buffer{},
-		Out:    &bytes.Buffer{},
-		ErrOut: &bytes.Buffer{},
-	}
-	return f, ioStreams
-}
-
-func (k *KubectlCmd) ReplaceResource(ctx context.Context, config *rest.Config, obj *unstructured.Unstructured, namespace string, dryRunStrategy cmdutil.DryRunStrategy, force bool) (string, error) {
-	span := k.Tracer.StartSpan("ReplaceResource")
-	span.SetBaggageItem("kind", obj.GetKind())
-	span.SetBaggageItem("name", obj.GetName())
-	defer span.Finish()
-	k.Log.Info(fmt.Sprintf("Replacing resource %s/%s in cluster: %s, namespace: %s", obj.GetKind(), obj.GetName(), config.Host, namespace))
-	return k.runResourceCommand(ctx, config, obj, namespace, dryRunStrategy, func(config *rest.Config, f cmdutil.Factory, ioStreams genericclioptions.IOStreams, fileName string, namespace string, dryRunStrategy cmdutil.DryRunStrategy) error {
-		cleanup, err := k.processKubectlRun("replace")
-		if err != nil {
-			return err
-		}
-		defer cleanup()
-
-		replaceOptions, err := newReplaceOptions(config, f, ioStreams, fileName, namespace, force, dryRunStrategy)
-		if err != nil {
-			return err
-		}
-		return replaceOptions.Run(f)
-	})
-}
-
-func (k *KubectlCmd) CreateResource(ctx context.Context, config *rest.Config, obj *unstructured.Unstructured, namespace string, dryRunStrategy cmdutil.DryRunStrategy) (*unstructured.Unstructured, error) {
-	gvk := obj.GroupVersionKind()
-	span := k.Tracer.StartSpan("CreateResource")
-	span.SetBaggageItem("kind", gvk.Kind)
-	span.SetBaggageItem("name", obj.GetName())
-	defer span.Finish()
-	dynamicIf, err := dynamic.NewForConfig(config)
-	if err != nil {
-		return nil, err
-	}
-	disco, err := discovery.NewDiscoveryClientForConfig(config)
-	if err != nil {
-		return nil, err
-	}
-	apiResource, err := ServerResourceForGroupVersionKind(disco, gvk)
-	if err != nil {
-		return nil, err
-	}
-	resource := gvk.GroupVersion().WithResource(apiResource.Name)
-	resourceIf := ToResourceInterface(dynamicIf, apiResource, resource, namespace)
-
-	createOptions := metav1.CreateOptions{}
-	switch dryRunStrategy {
-	case cmdutil.DryRunClient, cmdutil.DryRunServer:
-		createOptions.DryRun = []string{metav1.DryRunAll}
-	}
-	return resourceIf.Create(ctx, obj, createOptions)
-}
-
-func (k *KubectlCmd) UpdateResource(ctx context.Context, config *rest.Config, obj *unstructured.Unstructured, namespace string, dryRunStrategy cmdutil.DryRunStrategy) (*unstructured.Unstructured, error) {
-	gvk := obj.GroupVersionKind()
-	span := k.Tracer.StartSpan("UpdateResource")
-	span.SetBaggageItem("kind", gvk.Kind)
-	span.SetBaggageItem("name", obj.GetName())
-	defer span.Finish()
-	dynamicIf, err := dynamic.NewForConfig(config)
-	if err != nil {
-		return nil, err
-	}
-	disco, err := discovery.NewDiscoveryClientForConfig(config)
-	if err != nil {
-		return nil, err
-	}
-	apiResource, err := ServerResourceForGroupVersionKind(disco, gvk)
-	if err != nil {
-		return nil, err
-	}
-	resource := gvk.GroupVersion().WithResource(apiResource.Name)
-	resourceIf := ToResourceInterface(dynamicIf, apiResource, resource, namespace)
-
-	updateOptions := metav1.UpdateOptions{}
-	switch dryRunStrategy {
-	case cmdutil.DryRunClient, cmdutil.DryRunServer:
-		updateOptions.DryRun = []string{metav1.DryRunAll}
-	}
-	return resourceIf.Update(ctx, obj, updateOptions)
-}
-
-// ApplyResource performs an apply of a unstructured resource
-func (k *KubectlCmd) ApplyResource(ctx context.Context, config *rest.Config, obj *unstructured.Unstructured, namespace string, dryRunStrategy cmdutil.DryRunStrategy, force, validate bool) (string, error) {
-	span := k.Tracer.StartSpan("ApplyResource")
-	span.SetBaggageItem("kind", obj.GetKind())
-	span.SetBaggageItem("name", obj.GetName())
-	defer span.Finish()
-	k.Log.Info(fmt.Sprintf("Applying resource %s/%s in cluster: %s, namespace: %s", obj.GetKind(), obj.GetName(), config.Host, namespace))
-	return k.runResourceCommand(ctx, config, obj, namespace, dryRunStrategy, func(config *rest.Config, f cmdutil.Factory, ioStreams genericclioptions.IOStreams, fileName string, namespace string, dryRunStrategy cmdutil.DryRunStrategy) error {
-		cleanup, err := k.processKubectlRun("apply")
-		if err != nil {
-			return err
-		}
-		defer cleanup()
-
-		applyOpts, err := newApplyOptions(config, f, ioStreams, fileName, namespace, validate, force, dryRunStrategy)
-		if err != nil {
-			return err
-		}
-		return applyOpts.Run()
-	})
-}
-
-func newApplyOptions(config *rest.Config, f cmdutil.Factory, ioStreams genericclioptions.IOStreams, fileName string, namespace string, validate bool, force bool, dryRunStrategy cmdutil.DryRunStrategy) (*apply.ApplyOptions, error) {
-	o := apply.NewApplyOptions(ioStreams)
-	dynamicClient, err := dynamic.NewForConfig(config)
-	if err != nil {
-		return nil, err
-	}
-	o.DynamicClient = dynamicClient
-	o.DeleteOptions, err = o.DeleteFlags.ToOptions(dynamicClient, o.IOStreams)
-	if err != nil {
-		return nil, err
-	}
-	o.OpenAPISchema, err = f.OpenAPISchema()
-	if err != nil {
-		return nil, err
-	}
-	o.Validator, err = f.Validator(validate)
-	if err != nil {
-		return nil, err
-	}
-	discoveryClient, err := discovery.NewDiscoveryClientForConfig(config)
-	if err != nil {
-		return nil, err
-	}
-	o.DryRunVerifier = resource.NewDryRunVerifier(dynamicClient, discoveryClient)
-	o.Builder = f.NewBuilder()
-	o.Mapper, err = f.ToRESTMapper()
-	if err != nil {
-		return nil, err
-	}
-
-	o.ToPrinter = func(operation string) (printers.ResourcePrinter, error) {
-		o.PrintFlags.NamePrintFlags.Operation = operation
-		switch o.DryRunStrategy {
-		case cmdutil.DryRunClient:
-			err = o.PrintFlags.Complete("%s (dry run)")
-			if err != nil {
-				return nil, err
-			}
-		case cmdutil.DryRunServer:
-			err = o.PrintFlags.Complete("%s (server dry run)")
-			if err != nil {
-				return nil, err
-			}
-		}
-		return o.PrintFlags.ToPrinter()
-	}
-	o.DeleteOptions.FilenameOptions.Filenames = []string{fileName}
-	o.Namespace = namespace
-	o.DeleteOptions.ForceDeletion = force
-	o.DryRunStrategy = dryRunStrategy
-	return o, nil
-}
-
-func newReplaceOptions(config *rest.Config, f cmdutil.Factory, ioStreams genericclioptions.IOStreams, fileName string, namespace string, force bool, dryRunStrategy cmdutil.DryRunStrategy) (*replace.ReplaceOptions, error) {
-	o := replace.NewReplaceOptions(ioStreams)
-
-	recorder, err := o.RecordFlags.ToRecorder()
-	if err != nil {
-		return nil, err
-	}
-	o.Recorder = recorder
-
-	dynamicClient, err := dynamic.NewForConfig(config)
-	if err != nil {
-		return nil, err
-	}
-
-	o.DeleteOptions, err = o.DeleteFlags.ToOptions(dynamicClient, o.IOStreams)
-	if err != nil {
-		return nil, err
-	}
-	discoveryClient, err := discovery.NewDiscoveryClientForConfig(config)
-	if err != nil {
-		return nil, err
-	}
-	o.DryRunVerifier = resource.NewDryRunVerifier(dynamicClient, discoveryClient)
-	o.Builder = func() *resource.Builder {
-		return f.NewBuilder()
-	}
-
-	switch dryRunStrategy {
-	case cmdutil.DryRunClient:
-		err = o.PrintFlags.Complete("%s (dry run)")
-		if err != nil {
-			return nil, err
-		}
-	case cmdutil.DryRunServer:
-		err = o.PrintFlags.Complete("%s (server dry run)")
-		if err != nil {
-			return nil, err
-		}
-	}
-	o.DryRunStrategy = dryRunStrategy
-
-	printer, err := o.PrintFlags.ToPrinter()
-	if err != nil {
-		return nil, err
-	}
-	o.PrintObj = func(obj runtime.Object) error {
-		return printer.PrintObj(obj, o.Out)
-	}
-
-	o.DeleteOptions.FilenameOptions.Filenames = []string{fileName}
-	o.Namespace = namespace
-	o.DeleteOptions.ForceDeletion = force
-	return o, nil
-}
-
-func newReconcileOptions(f cmdutil.Factory, kubeClient *kubernetes.Clientset, fileName string, ioStreams genericclioptions.IOStreams, namespace string, dryRunStrategy cmdutil.DryRunStrategy) (*auth.ReconcileOptions, error) {
-	o := auth.NewReconcileOptions(ioStreams)
-	o.RBACClient = kubeClient.RbacV1()
-	o.NamespaceClient = kubeClient.CoreV1()
-	o.FilenameOptions.Filenames = []string{fileName}
-	o.DryRun = dryRunStrategy != cmdutil.DryRunNone
-
-	r := f.NewBuilder().
-		WithScheme(scheme.Scheme, scheme.Scheme.PrioritizedVersionsAllGroups()...).
-		NamespaceParam(namespace).DefaultNamespace().
-		FilenameParam(false, o.FilenameOptions).
-		Flatten().
-		Do()
-	o.Visitor = r
-
-	if o.DryRun {
-		err := o.PrintFlags.Complete("%s (dry run)")
-		if err != nil {
-			return nil, err
-		}
-	}
-	printer, err := o.PrintFlags.ToPrinter()
-	if err != nil {
-		return nil, err
-	}
-	o.PrintObject = printer.PrintObj
-	return o, nil
-}
-
-func (k *KubectlCmd) authReconcile(ctx context.Context, config *rest.Config, kubeconfigPath string, manifestFile string, namespace string, dryRunStrategy cmdutil.DryRunStrategy) (string, error) {
-	kubeClient, err := kubernetes.NewForConfig(config)
-	if err != nil {
-		return "", err
-	}
-	// `kubectl auth reconcile` has a side effect of auto-creating namespaces if it doesn't exist.
-	// See: https://github.com/kubernetes/kubernetes/issues/71185. This is behavior which we do
-	// not want. We need to check if the namespace exists, before know if it is safe to run this
-	// command. Skip this for dryRuns.
-	if dryRunStrategy == cmdutil.DryRunNone && namespace != "" {
-		_, err = kubeClient.CoreV1().Namespaces().Get(ctx, namespace, metav1.GetOptions{})
-		if err != nil {
-			return "", err
-		}
-	}
-	fact, ioStreams := kubeCmdFactory(kubeconfigPath, namespace)
-	reconcileOpts, err := newReconcileOptions(fact, kubeClient, manifestFile, ioStreams, namespace, dryRunStrategy)
-	if err != nil {
-		return "", err
-	}
-
-	err = reconcileOpts.Validate()
-	if err != nil {
-		return "", errors.New(cleanKubectlOutput(err.Error()))
-	}
-	err = reconcileOpts.RunReconcile()
-	if err != nil {
-		return "", errors.New(cleanKubectlOutput(err.Error()))
-	}
-
-	var out []string
-	if buf := strings.TrimSpace(ioStreams.Out.(*bytes.Buffer).String()); len(buf) > 0 {
-		out = append(out, buf)
-	}
-	if buf := strings.TrimSpace(ioStreams.ErrOut.(*bytes.Buffer).String()); len(buf) > 0 {
-		out = append(out, buf)
-	}
-	return strings.Join(out, ". "), nil
+	return &kubectlResourceOperations{
+		config:        config,
+		fact:          fact,
+		openAPISchema: openAPISchema,
+		tracer:        k.Tracer,
+		log:           k.Log,
+		onKubectlRun:  k.OnKubectlRun,
+	}, cleanup, nil
 }
 
 // ConvertToVersion converts an unstructured object into the specified group/version
@@ -626,13 +258,6 @@ func (k *KubectlCmd) GetServerVersion(config *rest.Config) (string, error) {
 
 func (k *KubectlCmd) NewDynamicClient(config *rest.Config) (dynamic.Interface, error) {
 	return dynamic.NewForConfig(config)
-}
-
-func (k *KubectlCmd) processKubectlRun(cmd string) (CleanupFunc, error) {
-	if k.OnKubectlRun != nil {
-		return k.OnKubectlRun(cmd)
-	}
-	return func() {}, nil
 }
 
 func (k *KubectlCmd) SetOnKubectlRun(onKubectlRun OnKubectlRunFunc) {

--- a/pkg/utils/kube/kubetest/mock.go
+++ b/pkg/utils/kube/kubetest/mock.go
@@ -89,7 +89,7 @@ func (k *MockKubectlCmd) DeleteResource(ctx context.Context, config *rest.Config
 	return command.Err
 }
 
-func (k *MockKubectlCmd) CreateResource(ctx context.Context, config *rest.Config, obj *unstructured.Unstructured, namespace string, dryRunStrategy cmdutil.DryRunStrategy) (*unstructured.Unstructured, error) {
+func (k *MockKubectlCmd) CreateResource(ctx context.Context, obj *unstructured.Unstructured, dryRunStrategy cmdutil.DryRunStrategy) (*unstructured.Unstructured, error) {
 	k.SetLastResourceCommand(kube.GetResourceKey(obj), "create")
 	command, ok := k.Commands[obj.GetName()]
 	if !ok {
@@ -98,7 +98,7 @@ func (k *MockKubectlCmd) CreateResource(ctx context.Context, config *rest.Config
 	return obj, command.Err
 }
 
-func (k *MockKubectlCmd) UpdateResource(ctx context.Context, config *rest.Config, obj *unstructured.Unstructured, namespace string, dryRunStrategy cmdutil.DryRunStrategy) (*unstructured.Unstructured, error) {
+func (k *MockKubectlCmd) UpdateResource(ctx context.Context, obj *unstructured.Unstructured, dryRunStrategy cmdutil.DryRunStrategy) (*unstructured.Unstructured, error) {
 	k.SetLastResourceCommand(kube.GetResourceKey(obj), "update")
 	command, ok := k.Commands[obj.GetName()]
 	if !ok {
@@ -107,7 +107,7 @@ func (k *MockKubectlCmd) UpdateResource(ctx context.Context, config *rest.Config
 	return obj, command.Err
 }
 
-func (k *MockKubectlCmd) ApplyResource(ctx context.Context, config *rest.Config, obj *unstructured.Unstructured, namespace string, dryRunStrategy cmdutil.DryRunStrategy, force, validate bool) (string, error) {
+func (k *MockKubectlCmd) ApplyResource(ctx context.Context, obj *unstructured.Unstructured, dryRunStrategy cmdutil.DryRunStrategy, force, validate bool) (string, error) {
 	k.SetLastValidate(validate)
 	k.SetLastResourceCommand(kube.GetResourceKey(obj), "apply")
 	command, ok := k.Commands[obj.GetName()]
@@ -117,7 +117,7 @@ func (k *MockKubectlCmd) ApplyResource(ctx context.Context, config *rest.Config,
 	return command.Output, command.Err
 }
 
-func (k *MockKubectlCmd) ReplaceResource(ctx context.Context, config *rest.Config, obj *unstructured.Unstructured, namespace string, dryRunStrategy cmdutil.DryRunStrategy, force bool) (string, error) {
+func (k *MockKubectlCmd) ReplaceResource(ctx context.Context, obj *unstructured.Unstructured, dryRunStrategy cmdutil.DryRunStrategy, force bool) (string, error) {
 	command, ok := k.Commands[obj.GetName()]
 	k.SetLastResourceCommand(kube.GetResourceKey(obj), "replace")
 	if !ok {
@@ -140,4 +140,10 @@ func (k *MockKubectlCmd) GetAPIGroups(config *rest.Config) ([]metav1.APIGroup, e
 }
 
 func (k *MockKubectlCmd) SetOnKubectlRun(onKubectlRun kube.OnKubectlRunFunc) {
+}
+
+func (k *MockKubectlCmd) ManageResources(config *rest.Config) (kube.ResourceOperations, func(), error) {
+	return k, func() {
+
+	}, nil
 }

--- a/pkg/utils/kube/resource_ops.go
+++ b/pkg/utils/kube/resource_ops.go
@@ -1,0 +1,424 @@
+package kube
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"strings"
+
+	"github.com/go-logr/logr"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/printers"
+	"k8s.io/cli-runtime/pkg/resource"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/kubectl/pkg/cmd/apply"
+	"k8s.io/kubectl/pkg/cmd/auth"
+	"k8s.io/kubectl/pkg/cmd/replace"
+	cmdutil "k8s.io/kubectl/pkg/cmd/util"
+	"k8s.io/kubectl/pkg/scheme"
+	"k8s.io/kubectl/pkg/util/openapi"
+
+	"github.com/argoproj/gitops-engine/pkg/diff"
+	"github.com/argoproj/gitops-engine/pkg/utils/io"
+	"github.com/argoproj/gitops-engine/pkg/utils/tracing"
+)
+
+// ResourceOperations provides methods to manage k8s resources
+type ResourceOperations interface {
+	ApplyResource(ctx context.Context, obj *unstructured.Unstructured, dryRunStrategy cmdutil.DryRunStrategy, force, validate bool) (string, error)
+	ReplaceResource(ctx context.Context, obj *unstructured.Unstructured, dryRunStrategy cmdutil.DryRunStrategy, force bool) (string, error)
+	CreateResource(ctx context.Context, obj *unstructured.Unstructured, dryRunStrategy cmdutil.DryRunStrategy) (*unstructured.Unstructured, error)
+	UpdateResource(ctx context.Context, obj *unstructured.Unstructured, dryRunStrategy cmdutil.DryRunStrategy) (*unstructured.Unstructured, error)
+}
+
+type kubectlResourceOperations struct {
+	config        *rest.Config
+	log           logr.Logger
+	tracer        tracing.Tracer
+	onKubectlRun  OnKubectlRunFunc
+	fact          cmdutil.Factory
+	openAPISchema openapi.Resources
+}
+
+type commandExecutor func(f cmdutil.Factory, ioStreams genericclioptions.IOStreams, fileName string) error
+
+func (k *kubectlResourceOperations) runResourceCommand(ctx context.Context, obj *unstructured.Unstructured, dryRunStrategy cmdutil.DryRunStrategy, executor commandExecutor) (string, error) {
+	manifestBytes, err := json.Marshal(obj)
+	if err != nil {
+		return "", err
+	}
+	manifestFile, err := ioutil.TempFile(io.TempDir, "")
+	if err != nil {
+		return "", fmt.Errorf("Failed to generate temp file for manifest: %v", err)
+	}
+	if _, err = manifestFile.Write(manifestBytes); err != nil {
+		return "", fmt.Errorf("Failed to write manifest: %v", err)
+	}
+	if err = manifestFile.Close(); err != nil {
+		return "", fmt.Errorf("Failed to close manifest: %v", err)
+	}
+	defer io.DeleteFile(manifestFile.Name())
+
+	// log manifest
+	if k.log.V(1).Enabled() {
+		var obj unstructured.Unstructured
+		err := json.Unmarshal(manifestBytes, &obj)
+		if err != nil {
+			return "", err
+		}
+		redacted, _, err := diff.HideSecretData(&obj, nil)
+		if err != nil {
+			return "", err
+		}
+		redactedBytes, err := json.Marshal(redacted)
+		if err != nil {
+			return "", err
+		}
+		k.log.V(1).Info(string(redactedBytes))
+	}
+
+	var out []string
+	if obj.GetAPIVersion() == "rbac.authorization.k8s.io/v1" {
+		// If it is an RBAC resource, run `kubectl auth reconcile`. This is preferred over
+		// `kubectl apply`, which cannot tolerate changes in roleRef, which is an immutable field.
+		// See: https://github.com/kubernetes/kubernetes/issues/66353
+		// `auth reconcile` will delete and recreate the resource if necessary
+		outReconcile, err := func() (string, error) {
+			cleanup, err := k.processKubectlRun("auth")
+			if err != nil {
+				return "", err
+			}
+			defer cleanup()
+			return k.authReconcile(ctx, obj, manifestFile.Name(), dryRunStrategy)
+		}()
+		if err != nil {
+			return "", err
+		}
+		out = append(out, outReconcile)
+		// We still want to fallthrough and run `kubectl apply` in order set the
+		// last-applied-configuration annotation in the object.
+	}
+
+	// Run kubectl apply
+	ioStreams := genericclioptions.IOStreams{
+		In:     &bytes.Buffer{},
+		Out:    &bytes.Buffer{},
+		ErrOut: &bytes.Buffer{},
+	}
+	err = executor(k.fact, ioStreams, manifestFile.Name())
+	if err != nil {
+		return "", errors.New(cleanKubectlOutput(err.Error()))
+	}
+	if buf := strings.TrimSpace(ioStreams.Out.(*bytes.Buffer).String()); len(buf) > 0 {
+		out = append(out, buf)
+	}
+	if buf := strings.TrimSpace(ioStreams.ErrOut.(*bytes.Buffer).String()); len(buf) > 0 {
+		out = append(out, buf)
+	}
+	return strings.Join(out, ". "), nil
+}
+
+func kubeCmdFactory(kubeconfig, ns string) cmdutil.Factory {
+	kubeConfigFlags := genericclioptions.NewConfigFlags(true)
+	if ns != "" {
+		kubeConfigFlags.Namespace = &ns
+	}
+	kubeConfigFlags.KubeConfig = &kubeconfig
+	matchVersionKubeConfigFlags := cmdutil.NewMatchVersionFlags(kubeConfigFlags)
+	return cmdutil.NewFactory(matchVersionKubeConfigFlags)
+}
+
+func (k *kubectlResourceOperations) ReplaceResource(ctx context.Context, obj *unstructured.Unstructured, dryRunStrategy cmdutil.DryRunStrategy, force bool) (string, error) {
+	span := k.tracer.StartSpan("ReplaceResource")
+	span.SetBaggageItem("kind", obj.GetKind())
+	span.SetBaggageItem("name", obj.GetName())
+	defer span.Finish()
+	k.log.Info(fmt.Sprintf("Replacing resource %s/%s in cluster: %s, namespace: %s", obj.GetKind(), obj.GetName(), k.config.Host, obj.GetNamespace()))
+	return k.runResourceCommand(ctx, obj, dryRunStrategy, func(f cmdutil.Factory, ioStreams genericclioptions.IOStreams, fileName string) error {
+		cleanup, err := k.processKubectlRun("replace")
+		if err != nil {
+			return err
+		}
+		defer cleanup()
+
+		replaceOptions, err := newReplaceOptions(k.config, f, ioStreams, fileName, obj.GetNamespace(), force, dryRunStrategy)
+		if err != nil {
+			return err
+		}
+		return replaceOptions.Run(f)
+	})
+}
+
+func (k *kubectlResourceOperations) CreateResource(ctx context.Context, obj *unstructured.Unstructured, dryRunStrategy cmdutil.DryRunStrategy) (*unstructured.Unstructured, error) {
+	gvk := obj.GroupVersionKind()
+	span := k.tracer.StartSpan("CreateResource")
+	span.SetBaggageItem("kind", gvk.Kind)
+	span.SetBaggageItem("name", obj.GetName())
+	defer span.Finish()
+	dynamicIf, err := dynamic.NewForConfig(k.config)
+	if err != nil {
+		return nil, err
+	}
+	disco, err := discovery.NewDiscoveryClientForConfig(k.config)
+	if err != nil {
+		return nil, err
+	}
+	apiResource, err := ServerResourceForGroupVersionKind(disco, gvk)
+	if err != nil {
+		return nil, err
+	}
+	resource := gvk.GroupVersion().WithResource(apiResource.Name)
+	resourceIf := ToResourceInterface(dynamicIf, apiResource, resource, obj.GetNamespace())
+
+	createOptions := metav1.CreateOptions{}
+	switch dryRunStrategy {
+	case cmdutil.DryRunClient, cmdutil.DryRunServer:
+		createOptions.DryRun = []string{metav1.DryRunAll}
+	}
+	return resourceIf.Create(ctx, obj, createOptions)
+}
+
+func (k *kubectlResourceOperations) UpdateResource(ctx context.Context, obj *unstructured.Unstructured, dryRunStrategy cmdutil.DryRunStrategy) (*unstructured.Unstructured, error) {
+	gvk := obj.GroupVersionKind()
+	span := k.tracer.StartSpan("UpdateResource")
+	span.SetBaggageItem("kind", gvk.Kind)
+	span.SetBaggageItem("name", obj.GetName())
+	defer span.Finish()
+	dynamicIf, err := dynamic.NewForConfig(k.config)
+	if err != nil {
+		return nil, err
+	}
+	disco, err := discovery.NewDiscoveryClientForConfig(k.config)
+	if err != nil {
+		return nil, err
+	}
+	apiResource, err := ServerResourceForGroupVersionKind(disco, gvk)
+	if err != nil {
+		return nil, err
+	}
+	resource := gvk.GroupVersion().WithResource(apiResource.Name)
+	resourceIf := ToResourceInterface(dynamicIf, apiResource, resource, obj.GetNamespace())
+
+	updateOptions := metav1.UpdateOptions{}
+	switch dryRunStrategy {
+	case cmdutil.DryRunClient, cmdutil.DryRunServer:
+		updateOptions.DryRun = []string{metav1.DryRunAll}
+	}
+	return resourceIf.Update(ctx, obj, updateOptions)
+}
+
+// ApplyResource performs an apply of a unstructured resource
+func (k *kubectlResourceOperations) ApplyResource(ctx context.Context, obj *unstructured.Unstructured, dryRunStrategy cmdutil.DryRunStrategy, force, validate bool) (string, error) {
+	span := k.tracer.StartSpan("ApplyResource")
+	span.SetBaggageItem("kind", obj.GetKind())
+	span.SetBaggageItem("name", obj.GetName())
+	defer span.Finish()
+	k.log.Info(fmt.Sprintf("Applying resource %s/%s in cluster: %s, namespace: %s", obj.GetKind(), obj.GetName(), k.config.Host, obj.GetNamespace()))
+	return k.runResourceCommand(ctx, obj, dryRunStrategy, func(f cmdutil.Factory, ioStreams genericclioptions.IOStreams, fileName string) error {
+		cleanup, err := k.processKubectlRun("apply")
+		if err != nil {
+			return err
+		}
+		defer cleanup()
+
+		applyOpts, err := k.newApplyOptions(ioStreams, obj, fileName, validate, force, dryRunStrategy)
+		if err != nil {
+			return err
+		}
+		return applyOpts.Run()
+	})
+}
+
+func (k *kubectlResourceOperations) newApplyOptions(ioStreams genericclioptions.IOStreams, obj *unstructured.Unstructured, fileName string, validate bool, force bool, dryRunStrategy cmdutil.DryRunStrategy) (*apply.ApplyOptions, error) {
+	o := apply.NewApplyOptions(ioStreams)
+	dynamicClient, err := dynamic.NewForConfig(k.config)
+	if err != nil {
+		return nil, err
+	}
+	o.DynamicClient = dynamicClient
+	o.DeleteOptions, err = o.DeleteFlags.ToOptions(dynamicClient, o.IOStreams)
+	if err != nil {
+		return nil, err
+	}
+	o.OpenAPISchema = k.openAPISchema
+	o.Validator, err = k.fact.Validator(validate)
+	if err != nil {
+		return nil, err
+	}
+	discoveryClient, err := discovery.NewDiscoveryClientForConfig(k.config)
+	if err != nil {
+		return nil, err
+	}
+	o.DryRunVerifier = resource.NewDryRunVerifier(dynamicClient, discoveryClient)
+	o.Builder = k.fact.NewBuilder()
+	o.Mapper, err = k.fact.ToRESTMapper()
+	if err != nil {
+		return nil, err
+	}
+
+	o.ToPrinter = func(operation string) (printers.ResourcePrinter, error) {
+		o.PrintFlags.NamePrintFlags.Operation = operation
+		switch o.DryRunStrategy {
+		case cmdutil.DryRunClient:
+			err = o.PrintFlags.Complete("%s (dry run)")
+			if err != nil {
+				return nil, err
+			}
+		case cmdutil.DryRunServer:
+			err = o.PrintFlags.Complete("%s (server dry run)")
+			if err != nil {
+				return nil, err
+			}
+		}
+		return o.PrintFlags.ToPrinter()
+	}
+	o.DeleteOptions.FilenameOptions.Filenames = []string{fileName}
+	o.Namespace = obj.GetNamespace()
+	o.DeleteOptions.ForceDeletion = force
+	o.DryRunStrategy = dryRunStrategy
+	return o, nil
+}
+
+func newReplaceOptions(config *rest.Config, f cmdutil.Factory, ioStreams genericclioptions.IOStreams, fileName string, namespace string, force bool, dryRunStrategy cmdutil.DryRunStrategy) (*replace.ReplaceOptions, error) {
+	o := replace.NewReplaceOptions(ioStreams)
+
+	recorder, err := o.RecordFlags.ToRecorder()
+	if err != nil {
+		return nil, err
+	}
+	o.Recorder = recorder
+
+	dynamicClient, err := dynamic.NewForConfig(config)
+	if err != nil {
+		return nil, err
+	}
+
+	o.DeleteOptions, err = o.DeleteFlags.ToOptions(dynamicClient, o.IOStreams)
+	if err != nil {
+		return nil, err
+	}
+	discoveryClient, err := discovery.NewDiscoveryClientForConfig(config)
+	if err != nil {
+		return nil, err
+	}
+	o.DryRunVerifier = resource.NewDryRunVerifier(dynamicClient, discoveryClient)
+	o.Builder = func() *resource.Builder {
+		return f.NewBuilder()
+	}
+
+	switch dryRunStrategy {
+	case cmdutil.DryRunClient:
+		err = o.PrintFlags.Complete("%s (dry run)")
+		if err != nil {
+			return nil, err
+		}
+	case cmdutil.DryRunServer:
+		err = o.PrintFlags.Complete("%s (server dry run)")
+		if err != nil {
+			return nil, err
+		}
+	}
+	o.DryRunStrategy = dryRunStrategy
+
+	printer, err := o.PrintFlags.ToPrinter()
+	if err != nil {
+		return nil, err
+	}
+	o.PrintObj = func(obj runtime.Object) error {
+		return printer.PrintObj(obj, o.Out)
+	}
+
+	o.DeleteOptions.FilenameOptions.Filenames = []string{fileName}
+	o.Namespace = namespace
+	o.DeleteOptions.ForceDeletion = force
+	return o, nil
+}
+
+func newReconcileOptions(f cmdutil.Factory, kubeClient *kubernetes.Clientset, fileName string, ioStreams genericclioptions.IOStreams, namespace string, dryRunStrategy cmdutil.DryRunStrategy) (*auth.ReconcileOptions, error) {
+	o := auth.NewReconcileOptions(ioStreams)
+	o.RBACClient = kubeClient.RbacV1()
+	o.NamespaceClient = kubeClient.CoreV1()
+	o.FilenameOptions.Filenames = []string{fileName}
+	o.DryRun = dryRunStrategy != cmdutil.DryRunNone
+
+	r := f.NewBuilder().
+		WithScheme(scheme.Scheme, scheme.Scheme.PrioritizedVersionsAllGroups()...).
+		NamespaceParam(namespace).DefaultNamespace().
+		FilenameParam(false, o.FilenameOptions).
+		Flatten().
+		Do()
+	o.Visitor = r
+
+	if o.DryRun {
+		err := o.PrintFlags.Complete("%s (dry run)")
+		if err != nil {
+			return nil, err
+		}
+	}
+	printer, err := o.PrintFlags.ToPrinter()
+	if err != nil {
+		return nil, err
+	}
+	o.PrintObject = printer.PrintObj
+	return o, nil
+}
+
+func (k *kubectlResourceOperations) authReconcile(ctx context.Context, obj *unstructured.Unstructured, manifestFile string, dryRunStrategy cmdutil.DryRunStrategy) (string, error) {
+	kubeClient, err := kubernetes.NewForConfig(k.config)
+	if err != nil {
+		return "", err
+	}
+	// `kubectl auth reconcile` has a side effect of auto-creating namespaces if it doesn't exist.
+	// See: https://github.com/kubernetes/kubernetes/issues/71185. This is behavior which we do
+	// not want. We need to check if the namespace exists, before know if it is safe to run this
+	// command. Skip this for dryRuns.
+	if dryRunStrategy == cmdutil.DryRunNone && obj.GetNamespace() != "" {
+		_, err = kubeClient.CoreV1().Namespaces().Get(ctx, obj.GetNamespace(), metav1.GetOptions{})
+		if err != nil {
+			return "", err
+		}
+	}
+	ioStreams := genericclioptions.IOStreams{
+		In:     &bytes.Buffer{},
+		Out:    &bytes.Buffer{},
+		ErrOut: &bytes.Buffer{},
+	}
+	reconcileOpts, err := newReconcileOptions(k.fact, kubeClient, manifestFile, ioStreams, obj.GetNamespace(), dryRunStrategy)
+	if err != nil {
+		return "", err
+	}
+
+	err = reconcileOpts.Validate()
+	if err != nil {
+		return "", errors.New(cleanKubectlOutput(err.Error()))
+	}
+	err = reconcileOpts.RunReconcile()
+	if err != nil {
+		return "", errors.New(cleanKubectlOutput(err.Error()))
+	}
+
+	var out []string
+	if buf := strings.TrimSpace(ioStreams.Out.(*bytes.Buffer).String()); len(buf) > 0 {
+		out = append(out, buf)
+	}
+	if buf := strings.TrimSpace(ioStreams.ErrOut.(*bytes.Buffer).String()); len(buf) > 0 {
+		out = append(out, buf)
+	}
+	return strings.Join(out, ". "), nil
+}
+
+func (k *kubectlResourceOperations) processKubectlRun(cmd string) (CleanupFunc, error) {
+	if k.onKubectlRun != nil {
+		return k.onKubectlRun(cmd)
+	}
+	return func() {}, nil
+}


### PR DESCRIPTION
Signed-off-by: Alexander Matyushentsev <AMatyushentsev@gmail.com>

Changes implemented in PR ensures that `sync_context` uses one instance of `cmdutil.Factory` from `github.com/kubernetes/kubectl` package to perform `kubectl apply/create/replace` operations. This significantly improves syncing performance and reduces memory usage. 

Tested with a sample app that consists of ~40 Config Maps. Synchronization is ~100 times faster (~0.2s instead of ~30s) and ~100 less memory usage ( ~16 mb instead of 1.3gb ).