### PR TITLE
feat: expose APIGroups in GetClusterInfo

### DIFF
--- a/pkg/cache/cluster.go
+++ b/pkg/cache/cluster.go
@@ -65,6 +65,8 @@ type ClusterInfo struct {
 	LastCacheSyncTime *time.Time
 	// SyncError holds most recent cache synchronization error
 	SyncError error
+	// APIGroups holds list of API groups supported by the cluster
+	APIGroups []metav1.APIGroup
 }
 
 // OnEventHandler is a function that handles Kubernetes event
@@ -942,6 +944,7 @@ func (c *clusterCache) GetClusterInfo() ClusterInfo {
 		Server:            c.config.Host,
 		LastCacheSyncTime: c.syncStatus.syncTime,
 		SyncError:         c.syncStatus.syncError,
+		APIGroups:         c.apiGroups,
 	}
 }
 

--- a/pkg/cache/cluster_test.go
+++ b/pkg/cache/cluster_test.go
@@ -577,6 +577,18 @@ func TestGetDuplicatedChildren(t *testing.T) {
 	}
 }
 
+func TestGetClusterInfo(t *testing.T) {
+	cluster := newCluster(t)
+	cluster.apiGroups = []metav1.APIGroup{{Name: "test"}}
+	cluster.serverVersion = "v1.16"
+	info := cluster.GetClusterInfo()
+	assert.Equal(t, ClusterInfo{
+		Server:     cluster.config.Host,
+		APIGroups:  cluster.apiGroups,
+		K8SVersion: cluster.serverVersion,
+	}, info)
+}
+
 func ExampleNewClusterCache_resourceUpdatedEvents() {
 	// kubernetes cluster config here
 	config := &rest.Config{}


### PR DESCRIPTION
Signed-off-by: Alexander Matyushentsev <AMatyushentsev@gmail.com>

PR allows getting a list of cluster API groups using the `GetClusterInfo` method.