### PR TITLE
refactor: stop caching OpenAPISchema since it is cached by cmdutil.Factory

### DIFF
--- a/pkg/utils/kube/ctl.go
+++ b/pkg/utils/kube/ctl.go
@@ -212,20 +212,15 @@ func (k *KubectlCmd) ManageResources(config *rest.Config) (ResourceOperations, f
 		return nil, nil, fmt.Errorf("Failed to write kubeconfig: %v", err)
 	}
 	fact := kubeCmdFactory(f.Name(), "")
-	openAPISchema, err := fact.OpenAPISchema()
-	if err != nil {
-		return nil, nil, err
-	}
 	cleanup := func() {
 		utils.DeleteFile(f.Name())
 	}
 	return &kubectlResourceOperations{
-		config:        config,
-		fact:          fact,
-		openAPISchema: openAPISchema,
-		tracer:        k.Tracer,
-		log:           k.Log,
-		onKubectlRun:  k.OnKubectlRun,
+		config:       config,
+		fact:         fact,
+		tracer:       k.Tracer,
+		log:          k.Log,
+		onKubectlRun: k.OnKubectlRun,
 	}, cleanup, nil
 }
 

--- a/pkg/utils/kube/resource_ops.go
+++ b/pkg/utils/kube/resource_ops.go
@@ -25,7 +25,6 @@ import (
 	"k8s.io/kubectl/pkg/cmd/replace"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 	"k8s.io/kubectl/pkg/scheme"
-	"k8s.io/kubectl/pkg/util/openapi"
 
 	"github.com/argoproj/gitops-engine/pkg/diff"
 	"github.com/argoproj/gitops-engine/pkg/utils/io"
@@ -41,12 +40,11 @@ type ResourceOperations interface {
 }
 
 type kubectlResourceOperations struct {
-	config        *rest.Config
-	log           logr.Logger
-	tracer        tracing.Tracer
-	onKubectlRun  OnKubectlRunFunc
-	fact          cmdutil.Factory
-	openAPISchema openapi.Resources
+	config       *rest.Config
+	log          logr.Logger
+	tracer       tracing.Tracer
+	onKubectlRun OnKubectlRunFunc
+	fact         cmdutil.Factory
 }
 
 type commandExecutor func(f cmdutil.Factory, ioStreams genericclioptions.IOStreams, fileName string) error
@@ -249,7 +247,10 @@ func (k *kubectlResourceOperations) newApplyOptions(ioStreams genericclioptions.
 	if err != nil {
 		return nil, err
 	}
-	o.OpenAPISchema = k.openAPISchema
+	o.OpenAPISchema, err = k.fact.OpenAPISchema()
+	if err != nil {
+		return nil, err
+	}
 	o.Validator, err = k.fact.Validator(validate)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Signed-off-by: Alexander Matyushentsev <AMatyushentsev@gmail.com>

PR is an attempt to fix https://github.com/argoproj/gitops-engine/issues/286 . After merging the https://github.com/argoproj/gitops-engine/pull/281 some sync operations intermittently fail with  `no matches for kind <Kind> in group <Group>` error. This error is returned by `RESTMapper` object that is created by `openapi.Resources` . The https://github.com/argoproj/gitops-engine/pull/281 introduced caching of `openapi.Resources` object that is probably the root cause of the issue. 

I've reverted that `openapi.Resources` caching and discovered that it does not affect performance. It is enough to cache just that `cmdutil.Factory` . Hence removing `openapi.Resources` caching. Hopefully, it will resolve the https://github.com/argoproj/gitops-engine/issues/286