### PR TITLE
refactor: using open api schema in cluster live state cache

### DIFF
--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -84,7 +84,7 @@ func (e *gitOpsEngine) Sync(ctx context.Context,
 		return nil, err
 	}
 	opts = append(opts, sync.WithSkipHooks(!diffRes.Modified))
-	syncCtx, cleanup, err := sync.NewSyncContext(revision, result, e.config, e.config, e.kubectl, namespace, opts...)
+	syncCtx, cleanup, err := sync.NewSyncContext(revision, result, e.config, e.config, e.kubectl, namespace, e.cache.GetOpenAPISchema(), opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sync/sync_context.go
+++ b/pkg/sync/sync_context.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/klog/v2/klogr"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
+	"k8s.io/kubectl/pkg/util/openapi"
 
 	"github.com/argoproj/gitops-engine/pkg/diff"
 	"github.com/argoproj/gitops-engine/pkg/health"
@@ -178,7 +179,7 @@ func WithReplace(replace bool) SyncOpt {
 	}
 }
 
-//  NewSyncContext creates new instance of a SyncContext
+// NewSyncContext creates new instance of a SyncContext
 func NewSyncContext(
 	revision string,
 	reconciliationResult ReconciliationResult,
@@ -186,6 +187,7 @@ func NewSyncContext(
 	rawConfig *rest.Config,
 	kubectl kubeutil.Kubectl,
 	namespace string,
+	openAPISchema openapi.Resources,
 	opts ...SyncOpt,
 ) (SyncContext, func(), error) {
 	dynamicIf, err := dynamic.NewForConfig(restConfig)
@@ -200,7 +202,7 @@ func NewSyncContext(
 	if err != nil {
 		return nil, nil, err
 	}
-	resourceOps, cleanup, err := kubectl.ManageResources(rawConfig)
+	resourceOps, cleanup, err := kubectl.ManageResources(rawConfig, openAPISchema)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/utils/kube/kubetest/mock.go
+++ b/pkg/utils/kube/kubetest/mock.go
@@ -12,6 +12,7 @@ import (
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/rest"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
+	"k8s.io/kubectl/pkg/util/openapi"
 
 	"github.com/argoproj/gitops-engine/pkg/utils/kube"
 )
@@ -139,10 +140,14 @@ func (k *MockKubectlCmd) GetAPIGroups(config *rest.Config) ([]metav1.APIGroup, e
 	return k.APIGroups, nil
 }
 
+func (k *MockKubectlCmd) LoadOpenAPISchema(config *rest.Config) (openapi.Resources, error) {
+	return nil, nil
+}
+
 func (k *MockKubectlCmd) SetOnKubectlRun(onKubectlRun kube.OnKubectlRunFunc) {
 }
 
-func (k *MockKubectlCmd) ManageResources(config *rest.Config) (kube.ResourceOperations, func(), error) {
+func (k *MockKubectlCmd) ManageResources(config *rest.Config, openAPISchema openapi.Resources) (kube.ResourceOperations, func(), error) {
 	return k, func() {
 
 	}, nil

--- a/pkg/utils/kube/resource_ops.go
+++ b/pkg/utils/kube/resource_ops.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/kubectl/pkg/cmd/replace"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 	"k8s.io/kubectl/pkg/scheme"
+	"k8s.io/kubectl/pkg/util/openapi"
 
 	"github.com/argoproj/gitops-engine/pkg/diff"
 	"github.com/argoproj/gitops-engine/pkg/utils/io"
@@ -40,11 +41,12 @@ type ResourceOperations interface {
 }
 
 type kubectlResourceOperations struct {
-	config       *rest.Config
-	log          logr.Logger
-	tracer       tracing.Tracer
-	onKubectlRun OnKubectlRunFunc
-	fact         cmdutil.Factory
+	config        *rest.Config
+	log           logr.Logger
+	tracer        tracing.Tracer
+	onKubectlRun  OnKubectlRunFunc
+	fact          cmdutil.Factory
+	openAPISchema openapi.Resources
 }
 
 type commandExecutor func(f cmdutil.Factory, ioStreams genericclioptions.IOStreams, fileName string) error
@@ -247,10 +249,7 @@ func (k *kubectlResourceOperations) newApplyOptions(ioStreams genericclioptions.
 	if err != nil {
 		return nil, err
 	}
-	o.OpenAPISchema, err = k.fact.OpenAPISchema()
-	if err != nil {
-		return nil, err
-	}
+	o.OpenAPISchema = k.openAPISchema
 	o.Validator, err = k.fact.Validator(validate)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Keep open api schema in cluster live state cache to avoid reloading it every sync

Signed-off-by: Alexander Matyushentsev <AMatyushentsev@gmail.com>