### PR TITLE
fix: workflows with empty status.phase should be considered Progressing

### DIFF
--- a/pkg/health/health_argo.go
+++ b/pkg/health/health_argo.go
@@ -8,13 +8,13 @@ import (
 type nodePhase string
 
 // Workflow and node statuses
+// See: https://github.com/argoproj/argo-workflows/blob/master/pkg/apis/workflow/v1alpha1/workflow_phase.go
 const (
 	nodePending   nodePhase = "Pending"
 	nodeRunning   nodePhase = "Running"
 	nodeSucceeded nodePhase = "Succeeded"
-	// nodeSkipped   nodePhase = "Skipped"
-	nodeFailed nodePhase = "Failed"
-	nodeError  nodePhase = "Error"
+	nodeFailed    nodePhase = "Failed"
+	nodeError     nodePhase = "Error"
 )
 
 // An agnostic workflow object only considers Status.Phase and Status.Message. It is agnostic to the API version or any
@@ -33,12 +33,12 @@ func getArgoWorkflowHealth(obj *unstructured.Unstructured) (*HealthStatus, error
 		return nil, err
 	}
 	switch wf.Status.Phase {
-	case nodePending, nodeRunning:
+	case "", nodePending, nodeRunning:
 		return &HealthStatus{Status: HealthStatusProgressing, Message: wf.Status.Message}, nil
 	case nodeSucceeded:
 		return &HealthStatus{Status: HealthStatusHealthy, Message: wf.Status.Message}, nil
 	case nodeFailed, nodeError:
 		return &HealthStatus{Status: HealthStatusDegraded, Message: wf.Status.Message}, nil
 	}
-	return &HealthStatus{Status: HealthStatusHealthy, Message: wf.Status.Message}, nil
+	return &HealthStatus{Status: HealthStatusUnknown, Message: wf.Status.Message}, nil
 }

--- a/pkg/health/health_test.go
+++ b/pkg/health/health_test.go
@@ -147,4 +147,18 @@ func TestGetArgoWorkflowHealth(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, HealthStatusHealthy, health.Status)
 	assert.Equal(t, "This node is has succeeded", health.Message)
+
+	sampleWorkflow = unstructured.Unstructured{Object: map[string]interface{}{
+		"spec": map[string]interface{}{
+			"entrypoint":    "sampleEntryPoint",
+			"extraneousKey": "we are agnostic to extraneous keys",
+		},
+	},
+	}
+
+	health, err = getArgoWorkflowHealth(&sampleWorkflow)
+	require.NoError(t, err)
+	assert.Equal(t, HealthStatusProgressing, health.Status)
+	assert.Equal(t, "", health.Message)
+
 }


### PR DESCRIPTION
Resolves https://github.com/argoproj/argo-cd/issues/6541

Workflows that have an empty `status.phase` have yet to be observed by the workflow controller, and should be considered Progressing, not Healthy.

Signed-off-by: Jesse Suen <jessesuen@gmail.com>