### PR TITLE
fix: 'ResourceOperations.CreateResource' should use 'kubectl' package to properly execute create operation

### DIFF
--- a/pkg/sync/sync_context.go
+++ b/pkg/sync/sync_context.go
@@ -857,12 +857,7 @@ func (sc *syncContext) applyObject(t *syncTask, dryRun bool, force bool, validat
 				message, err = sc.resourceOps.ReplaceResource(context.TODO(), t.targetObj, dryRunStrategy, force)
 			}
 		} else {
-			_, err = sc.resourceOps.CreateResource(context.TODO(), t.targetObj, dryRunStrategy)
-			if err == nil {
-				message = fmt.Sprintf("%s/%s created", t.targetObj.GetKind(), t.targetObj.GetName())
-			} else {
-				message = fmt.Sprintf("error when creating: %v", err.Error())
-			}
+			message, err = sc.resourceOps.CreateResource(context.TODO(), t.targetObj, dryRunStrategy, validate)
 		}
 	} else {
 		message, err = sc.resourceOps.ApplyResource(context.TODO(), t.targetObj, dryRunStrategy, force, validate)

--- a/pkg/utils/kube/kubetest/mock.go
+++ b/pkg/utils/kube/kubetest/mock.go
@@ -90,13 +90,13 @@ func (k *MockKubectlCmd) DeleteResource(ctx context.Context, config *rest.Config
 	return command.Err
 }
 
-func (k *MockKubectlCmd) CreateResource(ctx context.Context, obj *unstructured.Unstructured, dryRunStrategy cmdutil.DryRunStrategy) (*unstructured.Unstructured, error) {
+func (k *MockKubectlCmd) CreateResource(ctx context.Context, obj *unstructured.Unstructured, dryRunStrategy cmdutil.DryRunStrategy, validate bool) (string, error) {
 	k.SetLastResourceCommand(kube.GetResourceKey(obj), "create")
 	command, ok := k.Commands[obj.GetName()]
 	if !ok {
-		return obj, nil
+		return "", nil
 	}
-	return obj, command.Err
+	return command.Output, command.Err
 }
 
 func (k *MockKubectlCmd) UpdateResource(ctx context.Context, obj *unstructured.Unstructured, dryRunStrategy cmdutil.DryRunStrategy) (*unstructured.Unstructured, error) {


### PR DESCRIPTION
Signed-off-by: Alexander Matyushentsev <AMatyushentsev@gmail.com>

Closes https://github.com/argoproj/argo-cd/issues/6578

PR changes implementation of  'ResourceOperations.CreateResource' to use kubectl package so it won't fail incorrectly during dry run.