### PR TITLE
feat: Add support for resource anti-theft

### DIFF
--- a/pkg/sync/common/types.go
+++ b/pkg/sync/common/types.go
@@ -26,7 +26,9 @@ const (
 	// Sync option that enables pruneLast
 	SyncOptionPruneLast = "PruneLast=true"
 	// Sync option that enables use of replace or create command instead of apply
-	SyncOptionReplace = "Replace=true"
+	SyncOptionReplace    = "Replace=true"
+	// Sync option that allows one app to steal resources from another
+	SyncOptionAllowTheft = "Theft=true"
 )
 
 type PermissionValidator func(un *unstructured.Unstructured, res *metav1.APIResource) error

--- a/pkg/sync/sync_context.go
+++ b/pkg/sync/sync_context.go
@@ -87,16 +87,15 @@ type AntiTheftFunc func(liveObj, targetObj *unstructured.Unstructured) error
 // AntiTheftDisabled does not check for resource theft
 var AntiTheftDisabled AntiTheftFunc = func(_, _ *unstructured.Unstructured) error { return nil }
 
-// AntiTheftImmutableLabel prevents changing the label on a resource (e.g. app.kubernetes.io/name)
-var AntiTheftImmutableLabel = func(label string) AntiTheftFunc {
-	return func(liveObj, targetObj *unstructured.Unstructured) error {
-		if liveObj == nil || targetObj == nil {
+// AntiTheftLabel prevents changing the label on a resource (e.g. app.kubernetes.io/name)
+var AntiTheftLabel = func(label, value string) AntiTheftFunc {
+	return func(liveObj, _ *unstructured.Unstructured) error {
+		if liveObj == nil {
 			return nil
 		}
-		liveValue, exists := liveObj.GetLabels()[label]
-		targetValue := targetObj.GetAnnotations()[label]
-		if exists && targetValue != liveValue {
-			return fmt.Errorf("preventing resource theft: you may not change the label %q from %q to %q", label, liveValue, targetValue)
+		liveValue := liveObj.GetLabels()[label]
+		if value != liveValue {
+			return fmt.Errorf("anti-theft: you may not change the label %q from %q to %q", label, liveValue, value)
 		}
 		return nil
 	}

--- a/pkg/sync/sync_context_test.go
+++ b/pkg/sync/sync_context_test.go
@@ -1269,16 +1269,11 @@ func TestSyncContext_GetDeleteOptions_WithPrunePropagationPolicy(t *testing.T) {
 }
 
 func TestAntiTheftImmutableLabel(t *testing.T) {
-
-	const label = "my-label"
-	f := AntiTheftImmutableLabel(label)
-
-	assert.NoError(t, f(nil, nil))
-	assert.NoError(t, f(&unstructured.Unstructured{}, nil))
-	assert.NoError(t, f(&unstructured.Unstructured{}, &unstructured.Unstructured{}))
-
-	liveObj := &unstructured.Unstructured{}
-	liveObj.SetLabels(map[string]string{label: "my-live"})
-	assert.EqualError(t, f(liveObj, &unstructured.Unstructured{}), "preventing resource theft: you may not change the label \"my-label\" from \"my-live\" to \"\"")
-
+	f := AntiTheftLabel("my-label", "my-value")
+	t.Run("CreatingResource", func(t *testing.T) {
+		assert.NoError(t, f(nil, nil))
+	})
+	t.Run("DeletingResource", func(t *testing.T) {
+		assert.EqualError(t, f(&unstructured.Unstructured{}, nil), "anti-theft: you may not change the label \"my-label\" from \"\" to \"my-value\"")
+	})
 }

--- a/pkg/sync/sync_context_test.go
+++ b/pkg/sync/sync_context_test.go
@@ -1267,3 +1267,18 @@ func TestSyncContext_GetDeleteOptions_WithPrunePropagationPolicy(t *testing.T) {
 	opts := sc.getDeleteOptions()
 	assert.Equal(t, v1.DeletePropagationBackground, *opts.PropagationPolicy)
 }
+
+func TestAntiTheftImmutableLabel(t *testing.T) {
+
+	const label = "my-label"
+	f := AntiTheftImmutableLabel(label)
+
+	assert.NoError(t, f(nil, nil))
+	assert.NoError(t, f(&unstructured.Unstructured{}, nil))
+	assert.NoError(t, f(&unstructured.Unstructured{}, &unstructured.Unstructured{}))
+
+	liveObj := &unstructured.Unstructured{}
+	liveObj.SetLabels(map[string]string{label: "my-live"})
+	assert.EqualError(t, f(liveObj, &unstructured.Unstructured{}), "preventing resource theft: you may not change the label \"my-label\" from \"my-live\" to \"\"")
+
+}

--- a/pkg/sync/sync_context_test.go
+++ b/pkg/sync/sync_context_test.go
@@ -55,6 +55,7 @@ func newTestSyncCtx(opts ...SyncOpt) *syncContext {
 		resources: map[kube.ResourceKey]reconciledResource{},
 		syncRes:   map[string]synccommon.ResourceSyncResult{},
 		validate:  true,
+		antiTheft: AntiTheftDisabled,
 	}
 	sc.permissionValidator = func(un *unstructured.Unstructured, res *v1.APIResource) error {
 		return nil


### PR DESCRIPTION
Context:

Yesterday I accidentally deleted someone else's resources. To do this:

1. Make error in my manifests that create a cluster role with the same names as someone else's.
2. Sync my app, stealing the resources from the other app.
3. Correct the error in my app by prefixing the resource names.
4. Sync with prune (to remove the extraneous resources), which deleted the other user's resource.

I know I had to make a few mistakes, but Argo CD could have been prevented by erroring when I tried to sync and change the label.

