### PR TITLE
fix: add default protocol to subset of ports if it is empty

### DIFF
--- a/pkg/diff/diff.go
+++ b/pkg/diff/diff.go
@@ -517,6 +517,17 @@ func normalizeEndpoint(un *unstructured.Unstructured, o options) {
 		return
 	}
 
+	// add default protocol to subsets ports if it is empty
+	for s := range ep.Subsets {
+		subset := &ep.Subsets[s]
+		for p := range subset.Ports {
+			port := &subset.Ports[p]
+			if port.Protocol == "" {
+				port.Protocol = corev1.ProtocolTCP
+			}
+		}
+	}
+
 	endpoints.SortSubsets(ep.Subsets)
 
 	newObj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&ep)

--- a/pkg/diff/testdata/endpoints-config.json
+++ b/pkg/diff/testdata/endpoints-config.json
@@ -35,6 +35,19 @@
         {
           "name": "solr-http",
           "port": 8080
+        },
+        {
+          "name": "solr-https",
+          "port": 8443
+        },
+        {
+          "name": "solr-node",
+          "port": 8983,
+          "protocol": "UDP"
+        },
+        {
+          "name": "solr-zookeeper",
+          "port": 9983
         }
       ]
     }

--- a/pkg/diff/testdata/endpoints-live.json
+++ b/pkg/diff/testdata/endpoints-live.json
@@ -4,7 +4,7 @@
   "metadata": {
     "annotations": {
       "description": "A workaround to support a set of backend IPs for solr",
-      "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Endpoints\",\"metadata\":{\"annotations\":{\"description\":\"A workaround to support a set of backend IPs for solr\",\"linkerd.io/inject\":\"disabled\"},\"labels\":{\"app.kubernetes.io/instance\":\"guestbook\"},\"name\":\"solrcloud\",\"namespace\":\"default\"},\"subsets\":[{\"addresses\":[{\"ip\":\"172.20.10.97\"},{\"ip\":\"172.20.10.98\"},{\"ip\":\"172.20.10.99\"},{\"ip\":\"172.20.10.100\"},{\"ip\":\"172.20.10.101\"}],\"ports\":[{\"name\":\"solr-http\",\"port\":8080}]}]}\n",
+      "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Endpoints\",\"metadata\":{\"annotations\":{\"description\":\"A workaround to support a set of backend IPs for solr\",\"linkerd.io/inject\":\"disabled\"},\"labels\":{\"app.kubernetes.io/instance\":\"guestbook\"},\"name\":\"solrcloud\",\"namespace\":\"default\"},\"subsets\":[{\"addresses\":[{\"ip\":\"172.20.10.97\"},{\"ip\":\"172.20.10.98\"},{\"ip\":\"172.20.10.99\"},{\"ip\":\"172.20.10.100\"},{\"ip\":\"172.20.10.101\"}],\"ports\":[{\"name\":\"solr-http\",\"port\":8080},{\"name\":\"solr-https\",\"port\":8443},{\"name\":\"solr-node\",\"port\":8983,\"protocol\":\"UDP\"},{\"name\":\"solr-zookeeper\",\"port\":9983}]}]}\n",
       "linkerd.io/inject": "disabled"
     },
     "creationTimestamp": null,
@@ -32,24 +32,17 @@
         },
         "manager": "main",
         "operation": "Update",
-        "time": "2020-10-09T17:26:49Z"
+        "time": null
       }
     ],
     "name": "solrcloud",
     "namespace": "default",
-    "resourceVersion": "139834",
-    "selfLink": "/api/v1/namespaces/default/endpoints/solrcloud",
-    "uid": "f11285f4-987b-4194-bda8-6372b3f3f08f"
+    "resourceVersion": "2336",
+    "uid": "439a86ee-cbf9-4717-9ce3-d44079333a27"
   },
   "subsets": [
     {
       "addresses": [
-        {
-          "ip": "172.20.10.100"
-        },
-        {
-          "ip": "172.20.10.101"
-        },
         {
           "ip": "172.20.10.97"
         },
@@ -58,12 +51,33 @@
         },
         {
           "ip": "172.20.10.99"
+        },
+        {
+          "ip": "172.20.10.100"
+        },
+        {
+          "ip": "172.20.10.101"
         }
       ],
       "ports": [
         {
           "name": "solr-http",
           "port": 8080,
+          "protocol": "TCP"
+        },
+        {
+          "name": "solr-https",
+          "port": 8443,
+          "protocol": "TCP"
+        },
+        {
+          "name": "solr-node",
+          "port": 8983,
+          "protocol": "UDP"
+        },
+        {
+          "name": "solr-zookeeper",
+          "port": 9983,
           "protocol": "TCP"
         }
       ]


### PR DESCRIPTION
Signed-off-by: Roman Rudenko <3kmnazapad@gmail.com>

Fixes https://github.com/argoproj/argo-cd/issues/6300
by adding default protocol to subset of ports if it is not defined before sorting