### PR TITLE
feat: allow impersonate configuration

### DIFF
--- a/pkg/utils/kube/kube.go
+++ b/pkg/utils/kube/kube.go
@@ -278,6 +278,8 @@ func newAuthInfo(restConfig *rest.Config) *clientcmdapi.AuthInfo {
 		// well known token path. See issue #774
 		authInfo.TokenFile = "/var/run/secrets/kubernetes.io/serviceaccount/token"
 	}
+	authInfo.Impersonate = restConfig.Impersonate.UserName
+	authInfo.ImpersonateGroups = restConfig.Impersonate.Groups
 	return &authInfo
 }
 


### PR DESCRIPTION
With this change it would be possible to make a PR in argo-cd to support impersonation when writing to the cluster (argoproj/argo-cd#5275).