### PR TITLE
fix: Increase discovery config burst rate

### DIFF
--- a/pkg/utils/kube/resource_ops.go
+++ b/pkg/utils/kube/resource_ops.go
@@ -130,7 +130,7 @@ func (k *kubectlResourceOperations) runResourceCommand(ctx context.Context, obj 
 }
 
 func kubeCmdFactory(kubeconfig, ns string) cmdutil.Factory {
-	kubeConfigFlags := genericclioptions.NewConfigFlags(true)
+	kubeConfigFlags := genericclioptions.NewConfigFlags(true).WithDiscoveryBurst(350)
 	if ns != "" {
 		kubeConfigFlags.Namespace = &ns
 	}


### PR DESCRIPTION
This change increases the api call burst rate for the discovery client config.

On clusters with lots of CRDs (which is way more common these days), the default discovery burst rate of 100 is not enough, leading to massive slowdowns during sync operations because the client side rate-limiter kicks in (indicated by lots of "Waited for X.XXs due to client-side throttling, not priority and fairness").

During my tests with our OpenShift clusters (which have a lot of CRDs by default; our current setup has ~250), the creation of 100 ConfigMaps took 4:03 minutes (tested multiple times with different sync settings) without this change. After implementing this change, the time went down to 5 seconds.

In its own "oc" Kubernetes client for OpenShift, Redhat uses a burst rate of 250 (see https://bugzilla.redhat.com/show_bug.cgi?id=1899575) but in our experience, even this is not enough. Hence the value of 350 in this PR.