### PR TITLE
feat: configurable watch resync timeout. ability to disable cluster resync

### DIFF
--- a/pkg/cache/settings.go
+++ b/pkg/cache/settings.go
@@ -113,6 +113,13 @@ func SetResyncTimeout(timeout time.Duration) UpdateSettingsFunc {
 	}
 }
 
+// SetWatchResyncTimeout updates cluster re-sync timeout
+func SetWatchResyncTimeout(timeout time.Duration) UpdateSettingsFunc {
+	return func(cache *clusterCache) {
+		cache.watchResyncTimeout = timeout
+	}
+}
+
 // SetLogr sets the logger to use.
 func SetLogr(log logr.Logger) UpdateSettingsFunc {
 	return func(cache *clusterCache) {

--- a/pkg/cache/settings_test.go
+++ b/pkg/cache/settings_test.go
@@ -39,10 +39,19 @@ func TestSetNamespaces(t *testing.T) {
 
 func TestSetResyncTimeout(t *testing.T) {
 	cache := NewClusterCache(&rest.Config{})
-	assert.Equal(t, clusterResyncTimeout, cache.syncStatus.resyncTimeout)
+	assert.Equal(t, defaultClusterResyncTimeout, cache.syncStatus.resyncTimeout)
 
 	timeout := 1 * time.Hour
 	cache.Invalidate(SetResyncTimeout(timeout))
 
 	assert.Equal(t, timeout, cache.syncStatus.resyncTimeout)
+}
+
+func TestSetWatchResyncTimeout(t *testing.T) {
+	cache := NewClusterCache(&rest.Config{})
+	assert.Equal(t, defaultWatchResyncTimeout, cache.watchResyncTimeout)
+
+	timeout := 30 * time.Minute
+	cache = NewClusterCache(&rest.Config{}, SetWatchResyncTimeout(timeout))
+	assert.Equal(t, timeout, cache.watchResyncTimeout)
 }


### PR DESCRIPTION
When troubleshooting a users performance problem, I found many tunable were not configurable and hard wired into the gitops engine. So I made the following changes:

* Adds the ability to disable the 24h (12h in Argo CD) cluster resync period by setting the value to 0. This will result in the gitops-engine relying on the resource watch resync to correctly resync the cache.
* Also makes the resource watch resync period configurable (from the default of 10m)
* Watch resource resync can also be disabled by setting a value to 0

Signed-off-by: Jesse Suen <jesse@akuity.io>