### PR TITLE
fix: removeNamespaceAnnotation should not panic if annotation has unexpected value

### DIFF
--- a/pkg/diff/diff.go
+++ b/pkg/diff/diff.go
@@ -304,8 +304,8 @@ func removeNamespaceAnnotation(orig *unstructured.Unstructured) *unstructured.Un
 			if annotationsIf == nil {
 				shouldDelete = true
 			} else {
-				annotation := annotationsIf.(map[string]interface{})
-				if len(annotation) == 0 {
+				annotation, ok := annotationsIf.(map[string]interface{})
+				if ok && len(annotation) == 0 {
 					shouldDelete = true
 				}
 			}

--- a/pkg/diff/diff_test.go
+++ b/pkg/diff/diff_test.go
@@ -547,6 +547,17 @@ func TestRemoveNamespaceAnnotation(t *testing.T) {
 	}})
 	assert.Equal(t, "", obj.GetNamespace())
 	assert.Nil(t, obj.GetAnnotations())
+
+	obj = removeNamespaceAnnotation(&unstructured.Unstructured{Object: map[string]interface{}{
+		"metadata": map[string]interface{}{
+			"name":        "test",
+			"namespace":   "default",
+			"annotations": "wrong value",
+		},
+	}})
+	assert.Equal(t, "", obj.GetNamespace())
+	val, _, _ := unstructured.NestedString(obj.Object, "metadata", "annotations")
+	assert.Equal(t, "wrong value", val)
 }
 
 const customObjConfig = `


### PR DESCRIPTION
on behalf of @alexmt 

Signed-off-by: Leonardo Luz Almeida <leonardo_almeida@intuit.com>
