### PR TITLE
feat: expose cluster sync retry timeout

### DIFF
--- a/pkg/cache/settings.go
+++ b/pkg/cache/settings.go
@@ -120,6 +120,13 @@ func SetWatchResyncTimeout(timeout time.Duration) UpdateSettingsFunc {
 	}
 }
 
+// SetClusterSyncRetryTimeout updates cluster sync retry timeout when sync error happens
+func SetClusterSyncRetryTimeout(timeout time.Duration) UpdateSettingsFunc {
+	return func(cache *clusterCache) {
+		cache.clusterSyncRetryTimeout = timeout
+	}
+}
+
 // SetLogr sets the logger to use.
 func SetLogr(log logr.Logger) UpdateSettingsFunc {
 	return func(cache *clusterCache) {


### PR DESCRIPTION
Signed-off-by: Ben Ye <ben.ye@bytedance.com>

This pr exposes the sync retry duration when there is a sync error. The default is only 10s and for some large clusters, several unknown state apps will trigger a lot of full cluster sync every 10s.
Making it configurable improves the performance in the case above. Once this pr gets accepted then I will update the ArgoCD side as well.