### PR TITLE
feat: add IterateGroupHierarchy method to cache

### DIFF
--- a/pkg/cache/mocks/ClusterCache.go
+++ b/pkg/cache/mocks/ClusterCache.go
@@ -172,6 +172,11 @@ func (_m *ClusterCache) IsNamespaced(gk schema.GroupKind) (bool, error) {
 	return r0, r1
 }
 
+// IterateGroupHierarchy provides a mock function with given fields: key, action
+func (_m *ClusterCache) IterateGroupHierarchy(key []kube.ResourceKey, action func(*cache.Resource, map[kube.ResourceKey]*cache.Resource)) {
+	_m.Called(key, action)
+}
+
 // IterateHierarchy provides a mock function with given fields: key, action
 func (_m *ClusterCache) IterateHierarchy(key kube.ResourceKey, action func(*cache.Resource, map[kube.ResourceKey]*cache.Resource)) {
 	_m.Called(key, action)


### PR DESCRIPTION
Signed-off-by: Ben Ye <ben.ye@bytedance.com>

This pr adds a IterateGroupHierarchy method to execute multiple IterateHierarchy calls using goroutines and only takes the cluster read lock once.