### PR TITLE
fix: Add missing IngressClass in kind order when syncing tasks

### DIFF
--- a/pkg/sync/sync_tasks.go
+++ b/pkg/sync/sync_tasks.go
@@ -57,7 +57,7 @@ func init() {
 		"StatefulSet",
 		"Job",
 		"CronJob",
-		"IngressClass"
+		"IngressClass",
 		"Ingress",
 		"APIService",
 	}

--- a/pkg/sync/sync_tasks.go
+++ b/pkg/sync/sync_tasks.go
@@ -20,7 +20,7 @@ var syncPhaseOrder = map[common.SyncPhase]int{
 }
 
 // kindOrder represents the correct order of Kubernetes resources within a manifest
-// https://github.com/helm/helm/blob/146e0f9cc3b9c7ca9cb9dd0eba12de2270ae6faf/pkg/releaseutil/kind_sorter.go
+// https://github.com/helm/helm/blob/0361dc85689e3a6d802c444e2540c92cb5842bc9/pkg/releaseutil/kind_sorter.go
 var kindOrder = map[string]int{}
 
 func init() {
@@ -57,6 +57,7 @@ func init() {
 		"StatefulSet",
 		"Job",
 		"CronJob",
+		"IngressClass"
 		"Ingress",
 		"APIService",
 	}

--- a/pkg/sync/sync_tasks_test.go
+++ b/pkg/sync/sync_tasks_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func Test_syncTasks_kindOrder(t *testing.T) {
-	assert.Equal(t, -34, kindOrder["Namespace"])
+	assert.Equal(t, -35, kindOrder["Namespace"])
 	assert.Equal(t, -1, kindOrder["APIService"])
 	assert.Equal(t, 0, kindOrder["MyCRD"])
 }


### PR DESCRIPTION
Signed-off-by: Yuan Tang <terrytangyuan@gmail.com>