### PR TITLE
chore: Remove support for deprecated extensions APIs

### DIFF
--- a/pkg/health/health.go
+++ b/pkg/health/health.go
@@ -111,17 +111,6 @@ func GetHealthCheckFunc(gvk schema.GroupVersionKind) func(obj *unstructured.Unst
 		case kube.DaemonSetKind:
 			return getDaemonSetHealth
 		}
-	case "extensions":
-		switch gvk.Kind {
-		case kube.DeploymentKind:
-			return getDeploymentHealth
-		case kube.IngressKind:
-			return getIngressHealth
-		case kube.ReplicaSetKind:
-			return getReplicaSetHealth
-		case kube.DaemonSetKind:
-			return getDaemonSetHealth
-		}
 	case "argoproj.io":
 		switch gvk.Kind {
 		case "Workflow":

--- a/pkg/health/health.go
+++ b/pkg/health/health.go
@@ -111,6 +111,11 @@ func GetHealthCheckFunc(gvk schema.GroupVersionKind) func(obj *unstructured.Unst
 		case kube.DaemonSetKind:
 			return getDaemonSetHealth
 		}
+	case "extensions":
+		switch gvk.Kind {
+		case kube.IngressKind:
+			return getIngressHealth
+		}
 	case "argoproj.io":
 		switch gvk.Kind {
 		case "Workflow":

--- a/pkg/health/health_daemonset.go
+++ b/pkg/health/health_daemonset.go
@@ -5,8 +5,6 @@ import (
 
 	"github.com/argoproj/gitops-engine/pkg/utils/kube"
 	appsv1 "k8s.io/api/apps/v1"
-	appsv1beta2 "k8s.io/api/apps/v1beta2"
-	extv1beta1 "k8s.io/api/extensions/v1beta1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 )
@@ -21,20 +19,6 @@ func getDaemonSetHealth(obj *unstructured.Unstructured) (*HealthStatus, error) {
 			return nil, fmt.Errorf("failed to convert unstructured DaemonSet to typed: %v", err)
 		}
 		return getAppsv1DaemonSetHealth(&daemon)
-	case appsv1beta2.SchemeGroupVersion.WithKind(kube.DaemonSetKind):
-		var daemon appsv1beta2.DaemonSet
-		err := runtime.DefaultUnstructuredConverter.FromUnstructured(obj.Object, &daemon)
-		if err != nil {
-			return nil, fmt.Errorf("failed to convert unstructured DaemonSet to typed: %v", err)
-		}
-		return getAppsv1beta1DaemonSetHealth(&daemon)
-	case extv1beta1.SchemeGroupVersion.WithKind(kube.DaemonSetKind):
-		var daemon extv1beta1.DaemonSet
-		err := runtime.DefaultUnstructuredConverter.FromUnstructured(obj.Object, &daemon)
-		if err != nil {
-			return nil, fmt.Errorf("failed to convert unstructured DaemonSet to typed: %v", err)
-		}
-		return getExtv1beta1DaemonSetHealth(&daemon)
 	default:
 		return nil, fmt.Errorf("unsupported DaemonSet GVK: %s", gvk)
 	}
@@ -44,70 +28,6 @@ func getAppsv1DaemonSetHealth(daemon *appsv1.DaemonSet) (*HealthStatus, error) {
 	// Borrowed at kubernetes/kubectl/rollout_status.go https://github.com/kubernetes/kubernetes/blob/5232ad4a00ec93942d0b2c6359ee6cd1201b46bc/pkg/kubectl/rollout_status.go#L110
 	if daemon.Generation <= daemon.Status.ObservedGeneration {
 		if daemon.Spec.UpdateStrategy.Type == appsv1.OnDeleteDaemonSetStrategyType {
-			return &HealthStatus{
-				Status:  HealthStatusHealthy,
-				Message: fmt.Sprintf("daemon set %d out of %d new pods have been updated", daemon.Status.UpdatedNumberScheduled, daemon.Status.DesiredNumberScheduled),
-			}, nil
-		}
-		if daemon.Status.UpdatedNumberScheduled < daemon.Status.DesiredNumberScheduled {
-			return &HealthStatus{
-				Status:  HealthStatusProgressing,
-				Message: fmt.Sprintf("Waiting for daemon set %q rollout to finish: %d out of %d new pods have been updated...", daemon.Name, daemon.Status.UpdatedNumberScheduled, daemon.Status.DesiredNumberScheduled),
-			}, nil
-		}
-		if daemon.Status.NumberAvailable < daemon.Status.DesiredNumberScheduled {
-			return &HealthStatus{
-				Status:  HealthStatusProgressing,
-				Message: fmt.Sprintf("Waiting for daemon set %q rollout to finish: %d of %d updated pods are available...", daemon.Name, daemon.Status.NumberAvailable, daemon.Status.DesiredNumberScheduled),
-			}, nil
-		}
-	} else {
-		return &HealthStatus{
-			Status:  HealthStatusProgressing,
-			Message: "Waiting for rollout to finish: observed daemon set generation less then desired generation",
-		}, nil
-	}
-	return &HealthStatus{
-		Status: HealthStatusHealthy,
-	}, nil
-}
-
-func getAppsv1beta1DaemonSetHealth(daemon *appsv1beta2.DaemonSet) (*HealthStatus, error) {
-	// Borrowed at kubernetes/kubectl/rollout_status.go https://github.com/kubernetes/kubernetes/blob/5232ad4a00ec93942d0b2c6359ee6cd1201b46bc/pkg/kubectl/rollout_status.go#L110
-	if daemon.Generation <= daemon.Status.ObservedGeneration {
-		if daemon.Spec.UpdateStrategy.Type == appsv1beta2.OnDeleteDaemonSetStrategyType {
-			return &HealthStatus{
-				Status:  HealthStatusHealthy,
-				Message: fmt.Sprintf("daemon set %d out of %d new pods have been updated", daemon.Status.UpdatedNumberScheduled, daemon.Status.DesiredNumberScheduled),
-			}, nil
-		}
-		if daemon.Status.UpdatedNumberScheduled < daemon.Status.DesiredNumberScheduled {
-			return &HealthStatus{
-				Status:  HealthStatusProgressing,
-				Message: fmt.Sprintf("Waiting for daemon set %q rollout to finish: %d out of %d new pods have been updated...", daemon.Name, daemon.Status.UpdatedNumberScheduled, daemon.Status.DesiredNumberScheduled),
-			}, nil
-		}
-		if daemon.Status.NumberAvailable < daemon.Status.DesiredNumberScheduled {
-			return &HealthStatus{
-				Status:  HealthStatusProgressing,
-				Message: fmt.Sprintf("Waiting for daemon set %q rollout to finish: %d of %d updated pods are available...", daemon.Name, daemon.Status.NumberAvailable, daemon.Status.DesiredNumberScheduled),
-			}, nil
-		}
-	} else {
-		return &HealthStatus{
-			Status:  HealthStatusProgressing,
-			Message: "Waiting for rollout to finish: observed daemon set generation less then desired generation",
-		}, nil
-	}
-	return &HealthStatus{
-		Status: HealthStatusHealthy,
-	}, nil
-}
-
-func getExtv1beta1DaemonSetHealth(daemon *extv1beta1.DaemonSet) (*HealthStatus, error) {
-	// Borrowed at kubernetes/kubectl/rollout_status.go https://github.com/kubernetes/kubernetes/blob/5232ad4a00ec93942d0b2c6359ee6cd1201b46bc/pkg/kubectl/rollout_status.go#L110
-	if daemon.Generation <= daemon.Status.ObservedGeneration {
-		if daemon.Spec.UpdateStrategy.Type == extv1beta1.OnDeleteDaemonSetStrategyType {
 			return &HealthStatus{
 				Status:  HealthStatusHealthy,
 				Message: fmt.Sprintf("daemon set %d out of %d new pods have been updated", daemon.Status.UpdatedNumberScheduled, daemon.Status.DesiredNumberScheduled),

--- a/pkg/health/health_deployment.go
+++ b/pkg/health/health_deployment.go
@@ -5,8 +5,6 @@ import (
 
 	"github.com/argoproj/gitops-engine/pkg/utils/kube"
 	appsv1 "k8s.io/api/apps/v1"
-	appsv1beta1 "k8s.io/api/apps/v1beta1"
-	extv1beta1 "k8s.io/api/extensions/v1beta1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 )
@@ -21,20 +19,6 @@ func getDeploymentHealth(obj *unstructured.Unstructured) (*HealthStatus, error) 
 			return nil, fmt.Errorf("failed to convert unstructured Deployment to typed: %v", err)
 		}
 		return getAppsv1DeploymentHealth(&deployment)
-	case appsv1beta1.SchemeGroupVersion.WithKind(kube.DeploymentKind):
-		var deployment appsv1beta1.Deployment
-		err := runtime.DefaultUnstructuredConverter.FromUnstructured(obj.Object, &deployment)
-		if err != nil {
-			return nil, fmt.Errorf("failed to convert unstructured Deployment to typed: %v", err)
-		}
-		return getAppsv1beta1DeploymentHealth(&deployment)
-	case extv1beta1.SchemeGroupVersion.WithKind(kube.DeploymentKind):
-		var deployment extv1beta1.Deployment
-		err := runtime.DefaultUnstructuredConverter.FromUnstructured(obj.Object, &deployment)
-		if err != nil {
-			return nil, fmt.Errorf("failed to convert unstructured Deployment to typed: %v", err)
-		}
-		return getExtv1beta1DeploymentHealth(&deployment)
 	default:
 		return nil, fmt.Errorf("unsupported Deployment GVK: %s", gvk)
 	}
@@ -83,112 +67,7 @@ func getAppsv1DeploymentHealth(deployment *appsv1.Deployment) (*HealthStatus, er
 	}, nil
 }
 
-func getAppsv1beta1DeploymentHealth(deployment *appsv1beta1.Deployment) (*HealthStatus, error) {
-	if deployment.Spec.Paused {
-		return &HealthStatus{
-			Status:  HealthStatusSuspended,
-			Message: "Deployment is paused",
-		}, nil
-	}
-	// Borrowed at kubernetes/kubectl/rollout_status.go https://github.com/kubernetes/kubernetes/blob/5232ad4a00ec93942d0b2c6359ee6cd1201b46bc/pkg/kubectl/rollout_status.go#L80
-	if deployment.Generation <= deployment.Status.ObservedGeneration {
-		cond := getAppsv1beta1DeploymentCondition(deployment.Status, appsv1beta1.DeploymentProgressing)
-		if cond != nil && cond.Reason == "ProgressDeadlineExceeded" {
-			return &HealthStatus{
-				Status:  HealthStatusDegraded,
-				Message: fmt.Sprintf("Deployment %q exceeded its progress deadline", deployment.Name),
-			}, nil
-		} else if deployment.Spec.Replicas != nil && deployment.Status.UpdatedReplicas < *deployment.Spec.Replicas {
-			return &HealthStatus{
-				Status:  HealthStatusProgressing,
-				Message: fmt.Sprintf("Waiting for rollout to finish: %d out of %d new replicas have been updated...", deployment.Status.UpdatedReplicas, *deployment.Spec.Replicas),
-			}, nil
-		} else if deployment.Status.Replicas > deployment.Status.UpdatedReplicas {
-			return &HealthStatus{
-				Status:  HealthStatusProgressing,
-				Message: fmt.Sprintf("Waiting for rollout to finish: %d old replicas are pending termination...", deployment.Status.Replicas-deployment.Status.UpdatedReplicas),
-			}, nil
-		} else if deployment.Status.AvailableReplicas < deployment.Status.UpdatedReplicas {
-			return &HealthStatus{
-				Status:  HealthStatusProgressing,
-				Message: fmt.Sprintf("Waiting for rollout to finish: %d of %d updated replicas are available...", deployment.Status.AvailableReplicas, deployment.Status.UpdatedReplicas),
-			}, nil
-		}
-	} else {
-		return &HealthStatus{
-			Status:  HealthStatusProgressing,
-			Message: "Waiting for rollout to finish: observed deployment generation less then desired generation",
-		}, nil
-	}
-
-	return &HealthStatus{
-		Status: HealthStatusHealthy,
-	}, nil
-}
-
-func getExtv1beta1DeploymentHealth(deployment *extv1beta1.Deployment) (*HealthStatus, error) {
-	if deployment.Spec.Paused {
-		return &HealthStatus{
-			Status:  HealthStatusSuspended,
-			Message: "Deployment is paused",
-		}, nil
-	}
-	// Borrowed at kubernetes/kubectl/rollout_status.go https://github.com/kubernetes/kubernetes/blob/5232ad4a00ec93942d0b2c6359ee6cd1201b46bc/pkg/kubectl/rollout_status.go#L80
-	if deployment.Generation <= deployment.Status.ObservedGeneration {
-		cond := getExtv1beta1DeploymentCondition(deployment.Status, extv1beta1.DeploymentProgressing)
-		if cond != nil && cond.Reason == "ProgressDeadlineExceeded" {
-			return &HealthStatus{
-				Status:  HealthStatusDegraded,
-				Message: fmt.Sprintf("Deployment %q exceeded its progress deadline", deployment.Name),
-			}, nil
-		} else if deployment.Spec.Replicas != nil && deployment.Status.UpdatedReplicas < *deployment.Spec.Replicas {
-			return &HealthStatus{
-				Status:  HealthStatusProgressing,
-				Message: fmt.Sprintf("Waiting for rollout to finish: %d out of %d new replicas have been updated...", deployment.Status.UpdatedReplicas, *deployment.Spec.Replicas),
-			}, nil
-		} else if deployment.Status.Replicas > deployment.Status.UpdatedReplicas {
-			return &HealthStatus{
-				Status:  HealthStatusProgressing,
-				Message: fmt.Sprintf("Waiting for rollout to finish: %d old replicas are pending termination...", deployment.Status.Replicas-deployment.Status.UpdatedReplicas),
-			}, nil
-		} else if deployment.Status.AvailableReplicas < deployment.Status.UpdatedReplicas {
-			return &HealthStatus{
-				Status:  HealthStatusProgressing,
-				Message: fmt.Sprintf("Waiting for rollout to finish: %d of %d updated replicas are available...", deployment.Status.AvailableReplicas, deployment.Status.UpdatedReplicas),
-			}, nil
-		}
-	} else {
-		return &HealthStatus{
-			Status:  HealthStatusProgressing,
-			Message: "Waiting for rollout to finish: observed deployment generation less then desired generation",
-		}, nil
-	}
-
-	return &HealthStatus{
-		Status: HealthStatusHealthy,
-	}, nil
-}
-
 func getAppsv1DeploymentCondition(status appsv1.DeploymentStatus, condType appsv1.DeploymentConditionType) *appsv1.DeploymentCondition {
-	for i := range status.Conditions {
-		c := status.Conditions[i]
-		if c.Type == condType {
-			return &c
-		}
-	}
-	return nil
-}
-func getAppsv1beta1DeploymentCondition(status appsv1beta1.DeploymentStatus, condType appsv1beta1.DeploymentConditionType) *appsv1beta1.DeploymentCondition {
-	for i := range status.Conditions {
-		c := status.Conditions[i]
-		if c.Type == condType {
-			return &c
-		}
-	}
-	return nil
-}
-
-func getExtv1beta1DeploymentCondition(status extv1beta1.DeploymentStatus, condType extv1beta1.DeploymentConditionType) *extv1beta1.DeploymentCondition {
 	for i := range status.Conditions {
 		c := status.Conditions[i]
 		if c.Type == condType {

--- a/pkg/health/health_replicaset.go
+++ b/pkg/health/health_replicaset.go
@@ -5,9 +5,7 @@ import (
 
 	"github.com/argoproj/gitops-engine/pkg/utils/kube"
 	appsv1 "k8s.io/api/apps/v1"
-	appsv1beta2 "k8s.io/api/apps/v1beta2"
 	corev1 "k8s.io/api/core/v1"
-	extv1beta1 "k8s.io/api/extensions/v1beta1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 )
@@ -22,20 +20,6 @@ func getReplicaSetHealth(obj *unstructured.Unstructured) (*HealthStatus, error) 
 			return nil, fmt.Errorf("failed to convert unstructured ReplicaSet to typed: %v", err)
 		}
 		return getAppsv1ReplicaSetHealth(&replicaSet)
-	case appsv1beta2.SchemeGroupVersion.WithKind(kube.ReplicaSetKind):
-		var replicaSet appsv1beta2.ReplicaSet
-		err := runtime.DefaultUnstructuredConverter.FromUnstructured(obj.Object, &replicaSet)
-		if err != nil {
-			return nil, fmt.Errorf("failed to convert unstructured ReplicaSet to typed: %v", err)
-		}
-		return getAppsv1beta1ReplicaSetHealth(&replicaSet)
-	case extv1beta1.SchemeGroupVersion.WithKind(kube.ReplicaSetKind):
-		var replicaSet extv1beta1.ReplicaSet
-		err := runtime.DefaultUnstructuredConverter.FromUnstructured(obj.Object, &replicaSet)
-		if err != nil {
-			return nil, fmt.Errorf("failed to convert unstructured ReplicaSet to typed: %v", err)
-		}
-		return getExtv1beta1ReplicaSetHealth(&replicaSet)
 	default:
 		return nil, fmt.Errorf("unsupported ReplicaSet GVK: %s", gvk)
 	}
@@ -67,79 +51,7 @@ func getAppsv1ReplicaSetHealth(replicaSet *appsv1.ReplicaSet) (*HealthStatus, er
 	}, nil
 }
 
-func getAppsv1beta1ReplicaSetHealth(replicaSet *appsv1beta2.ReplicaSet) (*HealthStatus, error) {
-	if replicaSet.Generation <= replicaSet.Status.ObservedGeneration {
-		cond := getAppsv1beta2ReplicaSetCondition(replicaSet.Status, appsv1beta2.ReplicaSetReplicaFailure)
-		if cond != nil && cond.Status == corev1.ConditionTrue {
-			return &HealthStatus{
-				Status:  HealthStatusDegraded,
-				Message: cond.Message,
-			}, nil
-		} else if replicaSet.Spec.Replicas != nil && replicaSet.Status.AvailableReplicas < *replicaSet.Spec.Replicas {
-			return &HealthStatus{
-				Status:  HealthStatusProgressing,
-				Message: fmt.Sprintf("Waiting for rollout to finish: %d out of %d new replicas are available...", replicaSet.Status.AvailableReplicas, *replicaSet.Spec.Replicas),
-			}, nil
-		}
-	} else {
-		return &HealthStatus{
-			Status:  HealthStatusProgressing,
-			Message: "Waiting for rollout to finish: observed replica set generation less then desired generation",
-		}, nil
-	}
-
-	return &HealthStatus{
-		Status: HealthStatusHealthy,
-	}, nil
-}
-
-func getExtv1beta1ReplicaSetHealth(replicaSet *extv1beta1.ReplicaSet) (*HealthStatus, error) {
-	if replicaSet.Generation <= replicaSet.Status.ObservedGeneration {
-		cond := getExtv1beta1ReplicaSetCondition(replicaSet.Status, extv1beta1.ReplicaSetReplicaFailure)
-		if cond != nil && cond.Status == corev1.ConditionTrue {
-			return &HealthStatus{
-				Status:  HealthStatusDegraded,
-				Message: cond.Message,
-			}, nil
-		} else if replicaSet.Spec.Replicas != nil && replicaSet.Status.AvailableReplicas < *replicaSet.Spec.Replicas {
-			return &HealthStatus{
-				Status:  HealthStatusProgressing,
-				Message: fmt.Sprintf("Waiting for rollout to finish: %d out of %d new replicas are available...", replicaSet.Status.AvailableReplicas, *replicaSet.Spec.Replicas),
-			}, nil
-		}
-	} else {
-		return &HealthStatus{
-			Status:  HealthStatusProgressing,
-			Message: "Waiting for rollout to finish: observed replica set generation less then desired generation",
-		}, nil
-	}
-
-	return &HealthStatus{
-		Status: HealthStatusHealthy,
-	}, nil
-}
-
 func getAppsv1ReplicaSetCondition(status appsv1.ReplicaSetStatus, condType appsv1.ReplicaSetConditionType) *appsv1.ReplicaSetCondition {
-	for i := range status.Conditions {
-		c := status.Conditions[i]
-		if c.Type == condType {
-			return &c
-		}
-	}
-	return nil
-}
-
-func getAppsv1beta2ReplicaSetCondition(status appsv1beta2.ReplicaSetStatus, condType appsv1beta2.ReplicaSetConditionType) *appsv1beta2.ReplicaSetCondition {
-	for i := range status.Conditions {
-		c := status.Conditions[i]
-		if c.Type == condType {
-			return &c
-		}
-	}
-	return nil
-}
-
-func getExtv1beta1ReplicaSetCondition(status extv1beta1.ReplicaSetStatus, condType extv1beta1.ReplicaSetConditionType) *extv1beta1.ReplicaSetCondition {
 	for i := range status.Conditions {
 		c := status.Conditions[i]
 		if c.Type == condType {

--- a/pkg/health/health_statefulset.go
+++ b/pkg/health/health_statefulset.go
@@ -5,8 +5,6 @@ import (
 
 	"github.com/argoproj/gitops-engine/pkg/utils/kube"
 	appsv1 "k8s.io/api/apps/v1"
-	appsv1beta1 "k8s.io/api/apps/v1beta1"
-	appsv1beta2 "k8s.io/api/apps/v1beta2"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 )
@@ -21,20 +19,6 @@ func getStatefulSetHealth(obj *unstructured.Unstructured) (*HealthStatus, error)
 			return nil, fmt.Errorf("failed to convert unstructured StatefulSet to typed: %v", err)
 		}
 		return getAppsv1StatefulSetHealth(&sts)
-	case appsv1beta1.SchemeGroupVersion.WithKind(kube.StatefulSetKind):
-		var sts appsv1beta1.StatefulSet
-		err := runtime.DefaultUnstructuredConverter.FromUnstructured(obj.Object, &sts)
-		if err != nil {
-			return nil, fmt.Errorf("failed to convert unstructured StatefulSet to typed: %v", err)
-		}
-		return getAppsv1beta1StatefulSetHealth(&sts)
-	case appsv1beta2.SchemeGroupVersion.WithKind(kube.StatefulSetKind):
-		var sts appsv1beta2.StatefulSet
-		err := runtime.DefaultUnstructuredConverter.FromUnstructured(obj.Object, &sts)
-		if err != nil {
-			return nil, fmt.Errorf("failed to convert unstructured StatefulSet to typed: %v", err)
-		}
-		return getAppsv1beta2StatefulSetHealth(&sts)
 	default:
 		return nil, fmt.Errorf("unsupported StatefulSet GVK: %s", gvk)
 	}
@@ -70,105 +54,6 @@ func getAppsv1StatefulSetHealth(sts *appsv1.StatefulSet) (*HealthStatus, error) 
 		}, nil
 	}
 	if sts.Spec.UpdateStrategy.Type == appsv1.OnDeleteStatefulSetStrategyType {
-		return &HealthStatus{
-			Status:  HealthStatusHealthy,
-			Message: fmt.Sprintf("statefulset has %d ready pods", sts.Status.ReadyReplicas),
-		}, nil
-	}
-	if sts.Status.UpdateRevision != sts.Status.CurrentRevision {
-		return &HealthStatus{
-			Status:  HealthStatusProgressing,
-			Message: fmt.Sprintf("waiting for statefulset rolling update to complete %d pods at revision %s...", sts.Status.UpdatedReplicas, sts.Status.UpdateRevision),
-		}, nil
-	}
-	return &HealthStatus{
-		Status:  HealthStatusHealthy,
-		Message: fmt.Sprintf("statefulset rolling update complete %d pods at revision %s...", sts.Status.CurrentReplicas, sts.Status.CurrentRevision),
-	}, nil
-}
-
-func getAppsv1beta1StatefulSetHealth(sts *appsv1beta1.StatefulSet) (*HealthStatus, error) {
-	// Borrowed at kubernetes/kubectl/rollout_status.go https://github.com/kubernetes/kubernetes/blob/5232ad4a00ec93942d0b2c6359ee6cd1201b46bc/pkg/kubectl/rollout_status.go#L131
-	observedGeneration := sts.Status.ObservedGeneration
-	if observedGeneration == nil {
-		var x int64
-		observedGeneration = &x
-	}
-	if *observedGeneration == 0 || sts.Generation > *observedGeneration {
-		return &HealthStatus{
-			Status:  HealthStatusProgressing,
-			Message: "Waiting for statefulset spec update to be observed...",
-		}, nil
-	}
-	if sts.Spec.Replicas != nil && sts.Status.ReadyReplicas < *sts.Spec.Replicas {
-		return &HealthStatus{
-			Status:  HealthStatusProgressing,
-			Message: fmt.Sprintf("Waiting for %d pods to be ready...", *sts.Spec.Replicas-sts.Status.ReadyReplicas),
-		}, nil
-	}
-	if sts.Spec.UpdateStrategy.Type == appsv1beta1.RollingUpdateStatefulSetStrategyType && sts.Spec.UpdateStrategy.RollingUpdate != nil {
-		if sts.Spec.Replicas != nil && sts.Spec.UpdateStrategy.RollingUpdate.Partition != nil {
-			if sts.Status.UpdatedReplicas < (*sts.Spec.Replicas - *sts.Spec.UpdateStrategy.RollingUpdate.Partition) {
-				return &HealthStatus{
-					Status: HealthStatusProgressing,
-					Message: fmt.Sprintf("Waiting for partitioned roll out to finish: %d out of %d new pods have been updated...",
-						sts.Status.UpdatedReplicas, (*sts.Spec.Replicas - *sts.Spec.UpdateStrategy.RollingUpdate.Partition)),
-				}, nil
-			}
-		}
-		return &HealthStatus{
-			Status:  HealthStatusHealthy,
-			Message: fmt.Sprintf("partitioned roll out complete: %d new pods have been updated...", sts.Status.UpdatedReplicas),
-		}, nil
-	}
-	if sts.Spec.UpdateStrategy.Type == appsv1beta1.OnDeleteStatefulSetStrategyType {
-		return &HealthStatus{
-			Status:  HealthStatusHealthy,
-			Message: fmt.Sprintf("statefulset has %d ready pods", sts.Status.ReadyReplicas),
-		}, nil
-	}
-	if sts.Status.UpdateRevision != sts.Status.CurrentRevision {
-		return &HealthStatus{
-			Status:  HealthStatusProgressing,
-			Message: fmt.Sprintf("waiting for statefulset rolling update to complete %d pods at revision %s...", sts.Status.UpdatedReplicas, sts.Status.UpdateRevision),
-		}, nil
-	}
-	return &HealthStatus{
-		Status:  HealthStatusHealthy,
-		Message: fmt.Sprintf("statefulset rolling update complete %d pods at revision %s...", sts.Status.CurrentReplicas, sts.Status.CurrentRevision),
-	}, nil
-}
-
-func getAppsv1beta2StatefulSetHealth(sts *appsv1beta2.StatefulSet) (*HealthStatus, error) {
-	// Borrowed at kubernetes/kubectl/rollout_status.go https://github.com/kubernetes/kubernetes/blob/5232ad4a00ec93942d0b2c6359ee6cd1201b46bc/pkg/kubectl/rollout_status.go#L131
-	if sts.Status.ObservedGeneration == 0 || sts.Generation > sts.Status.ObservedGeneration {
-		return &HealthStatus{
-			Status:  HealthStatusProgressing,
-			Message: "Waiting for statefulset spec update to be observed...",
-		}, nil
-	}
-	if sts.Spec.Replicas != nil && sts.Status.ReadyReplicas < *sts.Spec.Replicas {
-		return &HealthStatus{
-			Status:  HealthStatusProgressing,
-			Message: fmt.Sprintf("Waiting for %d pods to be ready...", *sts.Spec.Replicas-sts.Status.ReadyReplicas),
-		}, nil
-	}
-	if sts.Spec.UpdateStrategy.Type == appsv1beta2.RollingUpdateStatefulSetStrategyType && sts.Spec.UpdateStrategy.RollingUpdate != nil {
-		if sts.Spec.Replicas != nil && sts.Spec.UpdateStrategy.RollingUpdate.Partition != nil {
-			if sts.Status.UpdatedReplicas < (*sts.Spec.Replicas - *sts.Spec.UpdateStrategy.RollingUpdate.Partition) {
-				return &HealthStatus{
-					Status: HealthStatusProgressing,
-					Message: fmt.Sprintf("Waiting for partitioned roll out to finish: %d out of %d new pods have been updated...",
-						sts.Status.UpdatedReplicas, (*sts.Spec.Replicas - *sts.Spec.UpdateStrategy.RollingUpdate.Partition)),
-				}, nil
-			}
-		}
-		return &HealthStatus{
-			Status:  HealthStatusHealthy,
-			Message: fmt.Sprintf("partitioned roll out complete: %d new pods have been updated...", sts.Status.UpdatedReplicas),
-		}, nil
-	}
-	if sts.Spec.UpdateStrategy.Type == appsv1beta2.OnDeleteStatefulSetStrategyType {
 		return &HealthStatus{
 			Status:  HealthStatusHealthy,
 			Message: fmt.Sprintf("statefulset has %d ready pods", sts.Status.ReadyReplicas),

--- a/pkg/health/testdata/deployment-degraded.yaml
+++ b/pkg/health/testdata/deployment-degraded.yaml
@@ -1,10 +1,10 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
     deployment.kubernetes.io/revision: "4"
     kubectl.kubernetes.io/last-applied-configuration: |
-      {"apiVersion":"apps/v1beta2","kind":"Deployment","metadata":{"annotations":{},"labels":{"app.kubernetes.io/instance":"guestbook-default"},"name":"guestbook-ui","namespace":"default"},"spec":{"replicas":1,"selector":{"matchLabels":{"app":"guestbook-ui"}},"template":{"metadata":{"labels":{"app":"guestbook-ui","app.kubernetes.io/instance":"guestbook-default"}},"spec":{"containers":[{"image":"gcr.io/heptio-images/ks-guestbook-demo:0.3","name":"guestbook-ui","ports":[{"containerPort":80}]}]}}}}
+      {"apiVersion":"apps/v1","kind":"Deployment","metadata":{"annotations":{},"labels":{"app.kubernetes.io/instance":"guestbook-default"},"name":"guestbook-ui","namespace":"default"},"spec":{"replicas":1,"selector":{"matchLabels":{"app":"guestbook-ui"}},"template":{"metadata":{"labels":{"app":"guestbook-ui","app.kubernetes.io/instance":"guestbook-default"}},"spec":{"containers":[{"image":"gcr.io/heptio-images/ks-guestbook-demo:0.3","name":"guestbook-ui","ports":[{"containerPort":80}]}]}}}}
   creationTimestamp: 2018-07-18T04:40:44Z
   generation: 4
   labels:
@@ -12,7 +12,7 @@ metadata:
   name: guestbook-ui
   namespace: default
   resourceVersion: "13660"
-  selfLink: /apis/extensions/v1beta1/namespaces/default/deployments/guestbook-ui
+  selfLink: /apis/apps/v1/namespaces/default/deployments/guestbook-ui
   uid: bb9af0c7-8a44-11e8-9e23-42010aa80010
 spec:
   progressDeadlineSeconds: 600

--- a/pkg/health/testdata/deployment-progressing.yaml
+++ b/pkg/health/testdata/deployment-progressing.yaml
@@ -1,10 +1,10 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
     deployment.kubernetes.io/revision: "4"
     kubectl.kubernetes.io/last-applied-configuration: |
-      {"apiVersion":"apps/v1beta2","kind":"Deployment","metadata":{"annotations":{},"labels":{"app.kubernetes.io/instance":"guestbook-default"},"name":"guestbook-ui","namespace":"default"},"spec":{"replicas":1,"selector":{"matchLabels":{"app":"guestbook-ui"}},"template":{"metadata":{"labels":{"app":"guestbook-ui","app.kubernetes.io/instance":"guestbook-default"}},"spec":{"containers":[{"image":"gcr.io/heptio-images/ks-guestbook-demo:0.3","name":"guestbook-ui","ports":[{"containerPort":80}]}]}}}}
+      {"apiVersion":"apps/v1","kind":"Deployment","metadata":{"annotations":{},"labels":{"app.kubernetes.io/instance":"guestbook-default"},"name":"guestbook-ui","namespace":"default"},"spec":{"replicas":1,"selector":{"matchLabels":{"app":"guestbook-ui"}},"template":{"metadata":{"labels":{"app":"guestbook-ui","app.kubernetes.io/instance":"guestbook-default"}},"spec":{"containers":[{"image":"gcr.io/heptio-images/ks-guestbook-demo:0.3","name":"guestbook-ui","ports":[{"containerPort":80}]}]}}}}
   creationTimestamp: 2018-07-18T04:40:44Z
   generation: 4
   labels:
@@ -12,7 +12,7 @@ metadata:
   name: guestbook-ui
   namespace: default
   resourceVersion: "12819"
-  selfLink: /apis/extensions/v1beta1/namespaces/default/deployments/guestbook-ui
+  selfLink: /apis/apps/v1/namespaces/default/deployments/guestbook-ui
   uid: bb9af0c7-8a44-11e8-9e23-42010aa80010
 spec:
   progressDeadlineSeconds: 600

--- a/pkg/health/testdata/deployment-suspended.yaml
+++ b/pkg/health/testdata/deployment-suspended.yaml
@@ -1,10 +1,10 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
     deployment.kubernetes.io/revision: "4"
     kubectl.kubernetes.io/last-applied-configuration: |
-      {"apiVersion":"apps/v1beta2","kind":"Deployment","metadata":{"annotations":{},"labels":{"app.kubernetes.io/instance":"guestbook-default"},"name":"guestbook-ui","namespace":"default"},"spec":{"replicas":1,"selector":{"matchLabels":{"app":"guestbook-ui"}},"template":{"metadata":{"labels":{"app":"guestbook-ui","app.kubernetes.io/instance":"guestbook-default"}},"spec":{"containers":[{"image":"gcr.io/heptio-images/ks-guestbook-demo:0.3","name":"guestbook-ui","ports":[{"containerPort":80}]}]}}}}
+      {"apiVersion":"apps/v1","kind":"Deployment","metadata":{"annotations":{},"labels":{"app.kubernetes.io/instance":"guestbook-default"},"name":"guestbook-ui","namespace":"default"},"spec":{"replicas":1,"selector":{"matchLabels":{"app":"guestbook-ui"}},"template":{"metadata":{"labels":{"app":"guestbook-ui","app.kubernetes.io/instance":"guestbook-default"}},"spec":{"containers":[{"image":"gcr.io/heptio-images/ks-guestbook-demo:0.3","name":"guestbook-ui","ports":[{"containerPort":80}]}]}}}}
   creationTimestamp: 2018-07-18T04:40:44Z
   generation: 4
   labels:
@@ -12,7 +12,7 @@ metadata:
   name: guestbook-ui
   namespace: default
   resourceVersion: "12819"
-  selfLink: /apis/extensions/v1beta1/namespaces/default/deployments/guestbook-ui
+  selfLink: /apis/apps/v1/namespaces/default/deployments/guestbook-ui
   uid: bb9af0c7-8a44-11e8-9e23-42010aa80010
 spec:
   progressDeadlineSeconds: 600

--- a/pkg/health/testdata/ingress-nonemptylist.yaml
+++ b/pkg/health/testdata/ingress-nonemptylist.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   generation: 1

--- a/pkg/health/testdata/ingress-unassigned.yaml
+++ b/pkg/health/testdata/ingress-unassigned.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
@@ -10,7 +10,7 @@ metadata:
   name: argocd-server-ingress
   namespace: argocd
   resourceVersion: "23207680"
-  selfLink: /apis/extensions/v1beta1/namespaces/argocd/ingresses/argocd-server-ingress
+  selfLink: /apis/networking.k8s.io/v1/namespaces/argocd/ingresses/argocd-server-ingress
   uid: 09927cae-bca1-11e8-bbd2-42010a8a00bb
 spec:
   rules:

--- a/pkg/health/testdata/ingress.yaml
+++ b/pkg/health/testdata/ingress.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
@@ -10,7 +10,7 @@ metadata:
   name: argocd-server-ingress
   namespace: argocd
   resourceVersion: "23207680"
-  selfLink: /apis/extensions/v1beta1/namespaces/argocd/ingresses/argocd-server-ingress
+  selfLink: /apis/networking.k8s.io/v1/namespaces/argocd/ingresses/argocd-server-ingress
   uid: 09927cae-bca1-11e8-bbd2-42010a8a00bb
 spec:
   rules:

--- a/pkg/utils/kube/ctl_test.go
+++ b/pkg/utils/kube/ctl_test.go
@@ -20,11 +20,11 @@ func TestConvertToVersion(t *testing.T) {
 		Tracer: tracing.NopTracer{},
 	}
 	t.Run("AppsDeployment", func(t *testing.T) {
-		newObj, err := kubectl.ConvertToVersion(testingutils.UnstructuredFromFile("testdata/appsdeployment.yaml"), "extensions", "v1beta1")
+		newObj, err := kubectl.ConvertToVersion(testingutils.UnstructuredFromFile("testdata/appsdeployment.yaml"), "apps", "v1")
 		if assert.NoError(t, err) {
 			gvk := newObj.GroupVersionKind()
-			assert.Equal(t, "extensions", gvk.Group)
-			assert.Equal(t, "v1beta1", gvk.Version)
+			assert.Equal(t, "apps", gvk.Group)
+			assert.Equal(t, "v1", gvk.Version)
 		}
 	})
 	t.Run("CustomResource", func(t *testing.T) {

--- a/pkg/utils/kube/testdata/nginx.yaml
+++ b/pkg/utils/kube/testdata/nginx.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
@@ -10,7 +10,7 @@ metadata:
   name: nginx-deployment
   namespace: default
   resourceVersion: "5140192"
-  selfLink: /apis/extensions/v1beta1/namespaces/default/deployments/nginx-deployment
+  selfLink: /apis/apps/v1/namespaces/default/deployments/nginx-deployment
   uid: fd131d5c-8035-11e8-a525-42010a8a006c
 spec:
   progressDeadlineSeconds: 600


### PR DESCRIPTION
This PR removed all extensions APIs besides Ingress because extensions Ingress is still available in 1.21. We will remove it later when 1.21 has reached to EOL.

Reference: https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/

Signed-off-by: Yuan Tang <terrytangyuan@gmail.com>