### PR TITLE
fix: Set QPS and burst rate for resource ops client

### DIFF
--- a/pkg/utils/kube/ctl.go
+++ b/pkg/utils/kube/ctl.go
@@ -208,14 +208,14 @@ func (k *KubectlCmd) DeleteResource(ctx context.Context, config *rest.Config, gv
 func (k *KubectlCmd) ManageResources(config *rest.Config, openAPISchema openapi.Resources) (ResourceOperations, func(), error) {
 	f, err := ioutil.TempFile(utils.TempDir, "")
 	if err != nil {
-		return nil, nil, fmt.Errorf("Failed to generate temp file for kubeconfig: %v", err)
+		return nil, nil, fmt.Errorf("failed to generate temp file for kubeconfig: %v", err)
 	}
 	_ = f.Close()
 	err = WriteKubeConfig(config, "", f.Name())
 	if err != nil {
-		return nil, nil, fmt.Errorf("Failed to write kubeconfig: %v", err)
+		return nil, nil, fmt.Errorf("failed to write kubeconfig: %v", err)
 	}
-	fact := kubeCmdFactory(f.Name(), "")
+	fact := kubeCmdFactory(f.Name(), "", config)
 	cleanup := func() {
 		utils.DeleteFile(f.Name())
 	}

--- a/pkg/utils/kube/resource_ops.go
+++ b/pkg/utils/kube/resource_ops.go
@@ -131,12 +131,14 @@ func (k *kubectlResourceOperations) runResourceCommand(ctx context.Context, obj 
 	return strings.Join(out, ". "), nil
 }
 
-func kubeCmdFactory(kubeconfig, ns string) cmdutil.Factory {
+func kubeCmdFactory(kubeconfig, ns string, config *rest.Config) cmdutil.Factory {
 	kubeConfigFlags := genericclioptions.NewConfigFlags(true)
 	if ns != "" {
 		kubeConfigFlags.Namespace = &ns
 	}
 	kubeConfigFlags.KubeConfig = &kubeconfig
+	kubeConfigFlags.WithDiscoveryBurst(config.Burst)
+	kubeConfigFlags.WithDiscoveryQPS(config.QPS)
 	matchVersionKubeConfigFlags := cmdutil.NewMatchVersionFlags(kubeConfigFlags)
 	return cmdutil.NewFactory(matchVersionKubeConfigFlags)
 }


### PR DESCRIPTION
This allows to set Kubernetes client QPS and burst rates for the resource ops client, according to the configuration of the client.

Needs a very small change in Argo CD as well, which will be submitted separately.

Supersedes #349 

Signed-off-by: jannfis <jann@mistrust.net>