### PR TITLE
chore: test resource conversion

### DIFF
--- a/pkg/cache/cluster_test.go
+++ b/pkg/cache/cluster_test.go
@@ -490,6 +490,8 @@ metadata:
 }
 
 func TestGetManagedLiveObjsFailedConversion(t *testing.T) {
+	cronTabGroup := "stable.example.com"
+
 	testCases := []struct{
 		name string
 		localConvertFails bool
@@ -518,8 +520,8 @@ func TestGetManagedLiveObjsFailedConversion(t *testing.T) {
 			cluster := newCluster(t, testCRD(), testCronTab()).
 				WithAPIResources([]kube.APIResourceInfo{
 					{
-						GroupKind:            schema.GroupKind{Group: "stable.example.com", Kind: "CronTab"},
-						GroupVersionResource: schema.GroupVersionResource{Group: "stable.example.com", Version: "v1", Resource: "crontabs"},
+						GroupKind:            schema.GroupKind{Group: cronTabGroup, Kind: "CronTab"},
+						GroupVersionResource: schema.GroupVersionResource{Group: cronTabGroup, Version: "v1", Resource: "crontabs"},
 						Meta:                 metav1.APIResource{Namespaced: true},
 					},
 				})
@@ -563,7 +565,7 @@ metadata:
 			assert.Equal(t, testCaseCopy.expectConvertToVersionCalled, convertToVersionWasCalled)
 			assert.Equal(t, testCaseCopy.expectGetResourceCalled, getResourceWasCalled)
 			assert.Equal(t, managedObjs, map[kube.ResourceKey]*unstructured.Unstructured{
-				kube.NewResourceKey("stable.example.com", "CronTab", "default", "test-crontab"): mustToUnstructured(testCronTab()),
+				kube.NewResourceKey(cronTabGroup, "CronTab", "default", "test-crontab"): mustToUnstructured(testCronTab()),
 			})
 		})
 	}

--- a/pkg/cache/cluster_test.go
+++ b/pkg/cache/cluster_test.go
@@ -1,7 +1,9 @@
 package cache
 
 import (
+	"context"
 	"fmt"
+	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
 	"sort"
 	"strings"
 	"testing"
@@ -105,6 +107,13 @@ func newCluster(t *testing.T, objs ...runtime.Object) *clusterCache {
 		cache.Invalidate()
 	})
 	return cache
+}
+
+func (c *clusterCache) WithAPIResources(newApiResources []kube.APIResourceInfo) *clusterCache {
+	apiResources := c.kubectl.(*kubetest.MockKubectlCmd).APIResources
+	apiResources = append(apiResources, newApiResources...)
+	c.kubectl.(*kubetest.MockKubectlCmd).APIResources = apiResources
+	return c
 }
 
 func getChildren(cluster *clusterCache, un *unstructured.Unstructured) []*Resource {
@@ -480,6 +489,86 @@ metadata:
 	assert.EqualError(t, err, "Namespace \"production\" for Deployment \"helm-guestbook\" is not managed")
 }
 
+func TestGetManagedLiveObjsFailedConversion(t *testing.T) {
+	testCases := []struct{
+		name string
+		localConvertFails bool
+		expectConvertToVersionCalled bool
+		expectGetResourceCalled bool
+	}{
+		{
+			name: "local convert fails, so GetResource is called",
+			localConvertFails: true,
+			expectConvertToVersionCalled: true,
+			expectGetResourceCalled: true,
+		},
+		{
+			name: "local convert succeeds, so GetResource is not called",
+			localConvertFails: false,
+			expectConvertToVersionCalled: true,
+			expectGetResourceCalled: false,
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCaseCopy := testCase
+		t.Run(testCaseCopy.name, func(t *testing.T) {
+			err := apiextensions.AddToScheme(scheme.Scheme)
+			require.NoError(t, err)
+			cluster := newCluster(t, testCRD(), testCronTab()).
+				WithAPIResources([]kube.APIResourceInfo{
+					{
+						GroupKind:            schema.GroupKind{Group: "stable.example.com", Kind: "CronTab"},
+						GroupVersionResource: schema.GroupVersionResource{Group: "stable.example.com", Version: "v1", Resource: "crontabs"},
+						Meta:                 metav1.APIResource{Namespaced: true},
+					},
+				})
+			cluster.Invalidate(SetPopulateResourceInfoHandler(func(un *unstructured.Unstructured, isRoot bool) (info interface{}, cacheManifest bool) {
+				return nil, true
+			}))
+			cluster.namespaces = []string{"default"}
+
+			err = cluster.EnsureSynced()
+			require.NoError(t, err)
+
+			targetDeploy := strToUnstructured(`
+apiVersion: stable.example.com/v1
+kind: CronTab
+metadata:
+  name: test-crontab
+  namespace: default`)
+
+			var convertToVersionWasCalled = false
+			var getResourceWasCalled = false
+			cluster.kubectl.(*kubetest.MockKubectlCmd).
+				WithConvertToVersionFunc(func(obj *unstructured.Unstructured, _ string, _ string) (*unstructured.Unstructured, error) {
+					convertToVersionWasCalled = true
+
+					if testCaseCopy.localConvertFails {
+						return nil, fmt.Errorf("failed to convert resource client-side")
+					}
+
+					return obj, nil
+				}).
+				WithGetResourceFunc(func(_ context.Context, _ *rest.Config, _ schema.GroupVersionKind, _ string, _ string) (*unstructured.Unstructured, error) {
+					getResourceWasCalled = true
+					return testCronTab(), nil
+				})
+
+
+			managedObjs, err := cluster.GetManagedLiveObjs([]*unstructured.Unstructured{targetDeploy}, func(r *Resource) bool {
+				return true
+			})
+			assert.NoError(t, err)
+			assert.Equal(t, testCaseCopy.expectConvertToVersionCalled, convertToVersionWasCalled)
+			assert.Equal(t, testCaseCopy.expectGetResourceCalled, getResourceWasCalled)
+			assert.Equal(t, managedObjs, map[kube.ResourceKey]*unstructured.Unstructured{
+				kube.NewResourceKey("stable.example.com", "CronTab", "default", "test-crontab"): mustToUnstructured(testCronTab()),
+			})
+		})
+	}
+}
+
 func TestChildDeletedEvent(t *testing.T) {
 	cluster := newCluster(t, testPod(), testRS(), testDeploy())
 	err := cluster.EnsureSynced()
@@ -721,6 +810,59 @@ func testPod() *corev1.Pod {
 			},
 		},
 	}
+}
+
+func testCRD() *apiextensions.CustomResourceDefinition {
+	return &apiextensions.CustomResourceDefinition{
+		TypeMeta:   metav1.TypeMeta{
+			APIVersion: "apiextensions.k8s.io/v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "crontabs.stable.example.com",
+		},
+		Spec:       apiextensions.CustomResourceDefinitionSpec{
+			Group: "stable.example.com",
+			Versions: []apiextensions.CustomResourceDefinitionVersion{
+				{
+					Name: "v1",
+					Served: true,
+					Storage: true,
+					Schema: &apiextensions.CustomResourceValidation{
+						OpenAPIV3Schema: &apiextensions.JSONSchemaProps{
+							Type: "object",
+							Properties: map[string]apiextensions.JSONSchemaProps{
+								"cronSpec": {Type: "string"},
+								"image": {Type: "string"},
+								"replicas": {Type: "integer"},
+							},
+						},
+					},
+				},
+			},
+			Scope: "Namespaced",
+			Names: apiextensions.CustomResourceDefinitionNames{
+				Plural:     "crontabs",
+				Singular:   "crontab",
+				ShortNames: []string{"ct"},
+				Kind:       "CronTab",
+			},
+		},
+	}
+}
+
+func testCronTab() *unstructured.Unstructured {
+	return &unstructured.Unstructured{Object: map[string]interface{}{
+		"apiVersion": "stable.example.com/v1",
+		"kind": "CronTab",
+		"metadata": map[string]interface{}{
+			"name": "test-crontab",
+			"namespace": "default",
+		},
+		"spec": map[string]interface{}{
+			"cronSpec": "* * * * */5",
+			"image": "my-awesome-cron-image",
+		},
+	}}
 }
 
 func testExtensionsRS() *extensionsv1beta1.ReplicaSet {


### PR DESCRIPTION
Argo CD currently has an e2e test which verifies that, if a resource version conversion isn't possible locally, we'll fall back to server-side conversion.

That test is difficult to maintain because it relies on having a CRD which is 1) not convertible locally and 2) _is_ convertible server-side for all supported k8s versions and whatever version of k8s the developer is running locally.

I want to [remove that e2e test](https://github.com/argoproj/argo-cd/issues/9046) because the maintenance overhead is excessive.

This PR checks for the behavior that the e2e test checks - do we fall back to server-side conversion if local conversion fails.