### PR TITLE
feat: Add support for HPA v2 (autoscaling/v2)

### DIFF
--- a/pkg/health/health_test.go
+++ b/pkg/health/health_test.go
@@ -78,6 +78,9 @@ func TestJob(t *testing.T) {
 }
 
 func TestHPA(t *testing.T) {
+	assertAppHealth(t, "./testdata/hpa-v2-healthy.yaml", HealthStatusHealthy)
+	assertAppHealth(t, "./testdata/hpa-v2-degraded.yaml", HealthStatusDegraded)
+	assertAppHealth(t, "./testdata/hpa-v2-progressing.yaml", HealthStatusProgressing)
 	assertAppHealth(t, "./testdata/hpa-v2beta2-healthy.yaml", HealthStatusHealthy)
 	assertAppHealth(t, "./testdata/hpa-v2beta1-healthy-disabled.yaml", HealthStatusHealthy)
 	assertAppHealth(t, "./testdata/hpa-v2beta1-healthy.yaml", HealthStatusHealthy)

--- a/pkg/health/testdata/hpa-v2-degraded.yaml
+++ b/pkg/health/testdata/hpa-v2-degraded.yaml
@@ -1,0 +1,42 @@
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  creationTimestamp: "2022-01-17T14:22:27Z"
+  name: sample
+  uid: 0e6d855e-83ed-4ed5-b80a-461a750f14db
+spec:
+  maxReplicas: 2
+  minReplicas: 1
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: argocd-server
+  targetCPUUtilizationPercentage: 80
+status:
+  conditions:
+  - lastTransitionTime: "2022-04-14T19:44:23Z"
+    message: 'the HPA controller was unable to get the target''s current scale: deployments/scale.apps
+      "sandbox-test-app-8" not found'
+    reason: FailedGetScale
+    status: "False"
+    type: AbleToScale
+  - lastTransitionTime: "2022-04-14T15:41:57Z"
+    message: the HPA was able to successfully calculate a replica count from cpu resource
+      utilization (percentage of request)
+    reason: ValidMetricFound
+    status: "True"
+    type: ScalingActive
+  - lastTransitionTime: "2022-01-17T14:24:13Z"
+    message: the desired count is within the acceptable range
+    reason: DesiredWithinRange
+    status: "False"
+    type: ScalingLimited
+  currentMetrics:
+  - resource:
+      current:
+        averageUtilization: 6
+        averageValue: 12m
+      name: cpu
+    type: Resource
+  currentReplicas: 1
+  desiredReplicas: 1

--- a/pkg/health/testdata/hpa-v2-healthy.yaml
+++ b/pkg/health/testdata/hpa-v2-healthy.yaml
@@ -1,0 +1,42 @@
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  creationTimestamp: '2022-05-13T12:39:31Z'
+  name: sample
+  uid: 0e6d855e-83ed-4ed5-b80a-461a750f14db
+spec:
+  maxReplicas: 2
+  minReplicas: 1
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: argocd-server
+  targetCPUUtilizationPercentage: 80
+status:
+  conditions:
+    - lastTransitionTime: '2022-05-13T12:40:34Z'
+      message: recommended size matches current size
+      reason: ReadyForNewScale
+      status: 'True'
+      type: AbleToScale
+    - lastTransitionTime: '2022-05-13T12:40:33Z'
+      message: >-
+        the HPA was able to successfully calculate a replica count from cpu
+        resource utilization (percentage of request)
+      reason: ValidMetricFound
+      status: 'True'
+      type: ScalingActive
+    - lastTransitionTime: '2022-05-13T12:40:31Z'
+      message: the desired count is within the acceptable range
+      reason: DesiredWithinRange
+      status: 'False'
+      type: ScalingLimited
+  currentMetrics:
+  - resource:
+      current:
+        averageUtilization: 6
+        averageValue: 12m
+      name: cpu
+    type: Resource
+  currentReplicas: 1
+  desiredReplicas: 1

--- a/pkg/health/testdata/hpa-v2-progressing.yaml
+++ b/pkg/health/testdata/hpa-v2-progressing.yaml
@@ -1,0 +1,37 @@
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  creationTimestamp: '2022-05-13T12:39:31Z'
+  name: sample
+  uid: 0e6d855e-83ed-4ed5-b80a-461a750f14db
+spec:
+  maxReplicas: 2
+  minReplicas: 1
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: argocd-server
+  targetCPUUtilizationPercentage: 80
+status:
+  conditions:
+    - lastTransitionTime: '2022-05-13T12:40:33Z'
+      message: >-
+        the HPA was able to successfully calculate a replica count from cpu
+        resource utilization (percentage of request)
+      reason: ValidMetricFound
+      status: 'True'
+      type: ScalingActive
+    - lastTransitionTime: '2022-05-13T12:40:31Z'
+      message: the desired count is within the acceptable range
+      reason: DesiredWithinRange
+      status: 'False'
+      type: ScalingLimited
+  currentMetrics:
+  - resource:
+      current:
+        averageUtilization: 6
+        averageValue: 12m
+      name: cpu
+    type: Resource
+  currentReplicas: 1
+  desiredReplicas: 1


### PR DESCRIPTION
Currently health check for HorizontalPodAutoscaler is limited to v1, v2beta1 and v2beta2. 
This MR adds support for v2 which is the default HPA API version on Kubernetes 1.23+

Without this MR, ArgoCD will fail to sync any applications that use HPA in Kubernetes 1.23+ clusters.