### PR TITLE
Use K8s version with .GitVersion

### DIFF
--- a/.gitconfig
+++ b/.gitconfig
@@ -1,3 +1,0 @@
-[user]
-        name = Zemtsov Vladimir
-        email = vl.zemtsov@gmail.com

--- a/.gitconfig
+++ b/.gitconfig
@@ -1,0 +1,3 @@
+[user]
+        name = Zemtsov Vladimir
+        email = vl.zemtsov@gmail.com

--- a/pkg/cache/cluster.go
+++ b/pkg/cache/cluster.go
@@ -1068,7 +1068,7 @@ func (c *clusterCache) GetClusterInfo() ClusterInfo {
 
 	return ClusterInfo{
 		APIsCount:         len(c.apisMeta),
-		K8SVersion:        c.serverVersion,
+		K8SVersion:        c.GetServerVersion(),
 		ResourcesCount:    len(c.resources),
 		Server:            c.config.Host,
 		LastCacheSyncTime: c.syncStatus.syncTime,

--- a/pkg/cache/cluster_test.go
+++ b/pkg/cache/cluster_test.go
@@ -731,9 +731,7 @@ func TestGetServerVersion(t *testing.T) {
 	cluster.serverVersion = &version.Info{
 		Major: "1",
 		Minor: "16",
-		// GitCommit: "v1.16.5",
 	}
-	// serverVersion := cluster.GetServerVersion()
 
 	assert.Equal(t, "1.16", cluster.GetServerVersion())
 }

--- a/pkg/cache/settings.go
+++ b/pkg/cache/settings.go
@@ -59,6 +59,13 @@ func SetSettings(settings Settings) UpdateSettingsFunc {
 	}
 }
 
+// SetFullServerVersion control ServerVersion. If 'true' - ServerVersion contain Kubernetes Patch version.
+func SetFullServerVersion(fullServerVersion bool) UpdateSettingsFunc {
+	return func(cache *clusterCache) {
+		cache.fullServerVersion = fullServerVersion
+	}
+}
+
 // SetNamespaces updates list of monitored namespaces
 func SetNamespaces(namespaces []string) UpdateSettingsFunc {
 	return func(cache *clusterCache) {

--- a/pkg/utils/kube/ctl.go
+++ b/pkg/utils/kube/ctl.go
@@ -36,7 +36,7 @@ type Kubectl interface {
 	GetResource(ctx context.Context, config *rest.Config, gvk schema.GroupVersionKind, name string, namespace string) (*unstructured.Unstructured, error)
 	PatchResource(ctx context.Context, config *rest.Config, gvk schema.GroupVersionKind, name string, namespace string, patchType types.PatchType, patchBytes []byte, subresources ...string) (*unstructured.Unstructured, error)
 	GetAPIResources(config *rest.Config, preferred bool, resourceFilter ResourceFilter) ([]APIResourceInfo, error)
-	GetServerVersion(config *rest.Config) (string, error)
+	GetServerVersion(config *rest.Config) (*version.Info, error)
 	NewDynamicClient(config *rest.Config) (dynamic.Interface, error)
 	SetOnKubectlRun(onKubectlRun OnKubectlRunFunc)
 }

--- a/pkg/utils/kube/ctl.go
+++ b/pkg/utils/kube/ctl.go
@@ -307,7 +307,7 @@ func (k *KubectlCmd) GetServerVersion(config *rest.Config) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return fmt.Sprintf("%s", v.GitCommit), nil
+	return v.GitCommit, nil
 }
 
 func (k *KubectlCmd) NewDynamicClient(config *rest.Config) (dynamic.Interface, error) {

--- a/pkg/utils/kube/ctl.go
+++ b/pkg/utils/kube/ctl.go
@@ -13,6 +13,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/managedfields"
+	"k8s.io/apimachinery/pkg/version"
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/rest"
@@ -296,18 +297,18 @@ func (k *KubectlCmd) ConvertToVersion(obj *unstructured.Unstructured, group stri
 	return convertToVersionWithScheme(obj, group, version)
 }
 
-func (k *KubectlCmd) GetServerVersion(config *rest.Config) (string, error) {
+func (k *KubectlCmd) GetServerVersion(config *rest.Config) (*version.Info, error) {
 	span := k.Tracer.StartSpan("GetServerVersion")
 	defer span.Finish()
 	client, err := discovery.NewDiscoveryClientForConfig(config)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 	v, err := client.ServerVersion()
 	if err != nil {
-		return "", err
+		return nil, err
 	}
-	return v.GitCommit, nil
+	return v, nil
 }
 
 func (k *KubectlCmd) NewDynamicClient(config *rest.Config) (dynamic.Interface, error) {

--- a/pkg/utils/kube/ctl.go
+++ b/pkg/utils/kube/ctl.go
@@ -307,7 +307,7 @@ func (k *KubectlCmd) GetServerVersion(config *rest.Config) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return fmt.Sprintf("%s.%s", v.Major, v.Minor), nil
+	return fmt.Sprintf("%s", v.GitCommit), nil
 }
 
 func (k *KubectlCmd) NewDynamicClient(config *rest.Config) (dynamic.Interface, error) {

--- a/pkg/utils/kube/kubetest/mock.go
+++ b/pkg/utils/kube/kubetest/mock.go
@@ -9,6 +9,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/managedfields"
+	"k8s.io/apimachinery/pkg/version"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/rest"
@@ -27,7 +28,7 @@ type MockKubectlCmd struct {
 	APIResources  []kube.APIResourceInfo
 	Commands      map[string]KubectlOutput
 	Events        chan watch.Event
-	Version       string
+	Version       *version.Info
 	DynamicClient dynamic.Interface
 
 	lastCommandPerResource map[kube.ResourceKey]string
@@ -170,7 +171,7 @@ func (k *MockKubectlCmd) ConvertToVersion(obj *unstructured.Unstructured, group,
 	return obj, nil
 }
 
-func (k *MockKubectlCmd) GetServerVersion(config *rest.Config) (string, error) {
+func (k *MockKubectlCmd) GetServerVersion(config *rest.Config) (*version.Info, error) {
 	return k.Version, nil
 }
 


### PR DESCRIPTION
Hello.
Everywhere in Kubernetes used GitVersion for demonstrated K8s version.
(For example `kubectl get nodes` returned exactly GitVersion of kubernetes)

It's important for me, bc i use ArgoCD for all Kubernetes Clusters and i want see Major.Minor.Patch version of kubernetes. But now i see only Major.Minor version.