### PR TITLE
fix: Change wrong log level in cluster.go openAPISchema, gvkParser

### DIFF
--- a/pkg/cache/cluster.go
+++ b/pkg/cache/cluster.go
@@ -666,7 +666,7 @@ func (c *clusterCache) watchEvents(ctx context.Context, api kube.APIResourceInfo
 							if !ok {
 								return err
 							}
-							c.log.Error(e, "warning loading openapi schema")
+							c.log.Warning(e, "warning loading openapi schema")
 						}
 						if gvkParser != nil {
 							c.gvkParser = gvkParser
@@ -730,7 +730,7 @@ func (c *clusterCache) sync() error {
 		if !ok {
 			return err
 		}
-		c.log.Error(e, "warning loading openapi schema")
+		c.log.Warning(e, "warning loading openapi schema")
 	}
 
 	if gvkParser != nil {

--- a/pkg/cache/cluster.go
+++ b/pkg/cache/cluster.go
@@ -666,7 +666,7 @@ func (c *clusterCache) watchEvents(ctx context.Context, api kube.APIResourceInfo
 							if !ok {
 								return err
 							}
-							c.log.Info(e, "warning loading openapi schema")
+							c.log.Info("warning loading openapi schema: %s", e)
 						}
 						if gvkParser != nil {
 							c.gvkParser = gvkParser
@@ -730,7 +730,7 @@ func (c *clusterCache) sync() error {
 		if !ok {
 			return err
 		}
-		c.log.Info(e, "warning loading openapi schema")
+		c.log.Info("warning loading openapi schema: %s", e)
 	}
 
 	if gvkParser != nil {

--- a/pkg/cache/cluster.go
+++ b/pkg/cache/cluster.go
@@ -666,7 +666,7 @@ func (c *clusterCache) watchEvents(ctx context.Context, api kube.APIResourceInfo
 							if !ok {
 								return err
 							}
-							c.log.Warning(e, "warning loading openapi schema")
+							c.log.Info(e, "warning loading openapi schema")
 						}
 						if gvkParser != nil {
 							c.gvkParser = gvkParser
@@ -730,7 +730,7 @@ func (c *clusterCache) sync() error {
 		if !ok {
 			return err
 		}
-		c.log.Warning(e, "warning loading openapi schema")
+		c.log.Info(e, "warning loading openapi schema")
 	}
 
 	if gvkParser != nil {


### PR DESCRIPTION
Fixes argoproj/gitops-engine#425

Change wrong log level from `Error` to `Warning`.