### PR TITLE
fix: Fix argument order in resource filter

### DIFF
--- a/pkg/sync/sync_context.go
+++ b/pkg/sync/sync_context.go
@@ -608,7 +608,7 @@ func (sc *syncContext) started() bool {
 }
 
 func (sc *syncContext) containsResource(resource reconciledResource) bool {
-	return sc.resourcesFilter == nil || sc.resourcesFilter(resource.key(), resource.Live, resource.Target)
+	return sc.resourcesFilter == nil || sc.resourcesFilter(resource.key(), resource.Target, resource.Live)
 }
 
 // generates the list of sync tasks we will be performing during this sync.


### PR DESCRIPTION
The signature for the `resourcesFilter` function in the sync context is

```go
resourcesFilter        func(key kube.ResourceKey, target *unstructured.Unstructured, live *unstructured.Unstructured) bool
```

but it's called with `live` and `target` exchanged.

This is a prerequisite for fixing https://github.com/argoproj/argo-cd/issues/8683

Signed-off-by: jannfis <jann@mistrust.net>