### PR TITLE
feat: add profile feature for agent, and fix logr's panic

### DIFF
--- a/agent/README.md
+++ b/agent/README.md
@@ -57,3 +57,20 @@ Update the container env [variables](https://github.com/kubernetes/git-sync#para
 ### Demo Recording
 
 [![asciicast](https://asciinema.org/a/FWbvVAiSsiI87wQx2TJbRMlxN.svg)](https://asciinema.org/a/FWbvVAiSsiI87wQx2TJbRMlxN)
+
+
+### Profiling
+
+Using env variables to enable profiling mode, the agent can be started with the following envs:
+
+```bash
+export GITOPS_ENGINE_PROFILE=web
+# optional, default pprofile address is 127.0.0.1:6060
+export GITOPS_ENGINE_PROFILE_HOST=127.0.0.1
+export GITOPS_ENGINE_PROFILE_PORT=6060
+```
+
+And then you can open profile in the browser(or using [pprof](https://github.com/google/pprof) cmd to generate diagrams):
+
+- http://127.0.0.1:6060/debug/pprof/goroutine?debug=2
+- http://127.0.0.1:6060/debug/pprof/mutex?debug=2

--- a/pkg/cache/cluster.go
+++ b/pkg/cache/cluster.go
@@ -730,7 +730,7 @@ func (c *clusterCache) sync() error {
 		if !ok {
 			return err
 		}
-		c.log.Info("warning loading openapi schema: %s", e)
+		c.log.Info("warning loading openapi schema: %s", e.Error())
 	}
 
 	if gvkParser != nil {

--- a/pkg/utils/text/text.go
+++ b/pkg/utils/text/text.go
@@ -8,3 +8,11 @@ func FirstNonEmpty(args ...string) string {
 	}
 	return ""
 }
+
+// WithDefault return defaultValue when val is blank
+func WithDefault(val string, defaultValue string) string {
+	if len(val) == 0 {
+		return defaultValue
+	}
+	return val
+}


### PR DESCRIPTION
## Feature

Using env variables to enable profiling mode, the agent can be started with the following envs:

```bash
export GITOPS_ENGINE_PROFILE=web
# optional, default pprofile address is 127.0.0.1:6060
export GITOPS_ENGINE_PROFILE_HOST=127.0.0.1
export GITOPS_ENGINE_PROFILE_PORT=6060
```

And then you can open profile in the browser(or using [pprof](https://github.com/google/pprof) cmd to generate diagrams):

- http://127.0.0.1:6060/debug/pprof/goroutine?debug=2
- http://127.0.0.1:6060/debug/pprof/mutex?debug=2

## Fix

logr will panic when format with none string params, error meesage:

```
key is not a string: "error creating gvk parser: duplicate entry for /v1, Kind=WatchEvent"
```
