### PR TITLE
Update namespace v2

### DIFF
--- a/pkg/sync/sync_context.go
+++ b/pkg/sync/sync_context.go
@@ -154,10 +154,11 @@ func WithResourceModificationChecker(enabled bool, diffResults *diff.DiffResultL
 }
 
 // WithNamespaceCreation will create non-exist namespace
-func WithNamespaceCreation(createNamespace bool, namespaceModifier func(*unstructured.Unstructured) bool) SyncOpt {
+func WithNamespaceCreation(createNamespace bool, namespaceModifier func(*unstructured.Unstructured) bool, namespaceCreator func(*unstructured.Unstructured) bool) SyncOpt {
 	return func(ctx *syncContext) {
 		ctx.createNamespace = createNamespace
 		ctx.namespaceModifier = namespaceModifier
+		ctx.namespaceCreator = namespaceCreator
 	}
 }
 
@@ -351,6 +352,7 @@ type syncContext struct {
 
 	createNamespace   bool
 	namespaceModifier func(*unstructured.Unstructured) bool
+	namespaceCreator  func(*unstructured.Unstructured) bool
 
 	syncWaveHook common.SyncWaveHook
 
@@ -816,7 +818,9 @@ func (sc *syncContext) autoCreateNamespace(tasks syncTasks) syncTasks {
 					}
 				}
 			} else if apierr.IsNotFound(err) {
-				tasks = append(tasks, &syncTask{phase: common.SyncPhasePreSync, targetObj: unstructuredObj, liveObj: nil})
+				if sc.namespaceCreator(unstructuredObj) {
+					tasks = append(tasks, &syncTask{phase: common.SyncPhasePreSync, targetObj: unstructuredObj, liveObj: nil})
+				}
 			} else {
 				task := &syncTask{phase: common.SyncPhasePreSync, targetObj: unstructuredObj}
 				sc.setResourceResult(task, common.ResultCodeSyncFailed, common.OperationError, fmt.Sprintf("Namespace auto creation failed: %s", err))

--- a/pkg/sync/sync_context.go
+++ b/pkg/sync/sync_context.go
@@ -153,12 +153,13 @@ func WithResourceModificationChecker(enabled bool, diffResults *diff.DiffResultL
 	}
 }
 
-// WithNamespaceCreation will create non-exist namespace
-func WithNamespaceCreation(createNamespace bool, namespaceModifier func(*unstructured.Unstructured) bool, namespaceCreator func(*unstructured.Unstructured) bool) SyncOpt {
+// WithNamespaceModifier will create a namespace with the metadata passed in the `*unstructured.Unstructured` argument
+// of the `namespaceModifier` function, in the case it returns `true`. If the namespace already exists, the metadata
+// will overwrite what is already present if `namespaceModifier` returns `true`. If `namespaceModifier` returns `false`,
+// this will be a no-op.
+func WithNamespaceModifier(namespaceModifier func(*unstructured.Unstructured) (bool, error)) SyncOpt {
 	return func(ctx *syncContext) {
-		ctx.createNamespace = createNamespace
 		ctx.namespaceModifier = namespaceModifier
-		ctx.namespaceCreator = namespaceCreator
 	}
 }
 
@@ -350,9 +351,7 @@ type syncContext struct {
 	// lock to protect concurrent updates of the result list
 	lock sync.Mutex
 
-	createNamespace   bool
-	namespaceModifier func(*unstructured.Unstructured) bool
-	namespaceCreator  func(*unstructured.Unstructured) bool
+	namespaceModifier func(*unstructured.Unstructured) (bool, error)
 
 	syncWaveHook common.SyncWaveHook
 
@@ -687,7 +686,7 @@ func (sc *syncContext) getSyncTasks() (_ syncTasks, successful bool) {
 		}
 	}
 
-	if sc.createNamespace && sc.namespace != "" {
+	if sc.namespaceModifier != nil && sc.namespace != "" {
 		tasks = sc.autoCreateNamespace(tasks)
 	}
 
@@ -809,27 +808,40 @@ func (sc *syncContext) autoCreateNamespace(tasks syncTasks) syncTasks {
 				nsTask := &syncTask{phase: common.SyncPhasePreSync, targetObj: unstructuredObj, liveObj: liveObj}
 				_, ok := sc.syncRes[nsTask.resultKey()]
 				if ok {
-					tasks = append(tasks, nsTask)
+					tasks = sc.appendNsTask(tasks, nsTask, unstructuredObj)
 				} else {
-					sc.log.WithValues("namespace", sc.namespace).Info("Namespace already exists")
-					liveObjCopy := liveObj.DeepCopy()
-					if sc.namespaceModifier(liveObjCopy) {
-						tasks = append(tasks, &syncTask{phase: common.SyncPhasePreSync, targetObj: liveObjCopy, liveObj: liveObj})
+					if liveObj != nil {
+						sc.log.WithValues("namespace", sc.namespace).Info("Namespace already exists")
+						tasks = sc.appendNsTask(tasks, &syncTask{phase: common.SyncPhasePreSync, targetObj: unstructuredObj, liveObj: liveObj}, unstructuredObj)
 					}
 				}
 			} else if apierr.IsNotFound(err) {
-				if sc.namespaceCreator(unstructuredObj) {
-					tasks = append(tasks, &syncTask{phase: common.SyncPhasePreSync, targetObj: unstructuredObj, liveObj: nil})
-				}
+				tasks = sc.appendNsTask(tasks, &syncTask{phase: common.SyncPhasePreSync, targetObj: unstructuredObj, liveObj: nil}, unstructuredObj)
 			} else {
-				task := &syncTask{phase: common.SyncPhasePreSync, targetObj: unstructuredObj}
-				sc.setResourceResult(task, common.ResultCodeSyncFailed, common.OperationError, fmt.Sprintf("Namespace auto creation failed: %s", err))
-				tasks = append(tasks, task)
+				tasks = sc.appendFailedNsTask(tasks, unstructuredObj, fmt.Errorf("Namespace auto creation failed: %s", err))
 			}
 		} else {
 			sc.setOperationPhase(common.OperationFailed, fmt.Sprintf("Namespace auto creation failed: %s", err))
 		}
 	}
+	return tasks
+}
+
+func (sc *syncContext) appendNsTask(tasks syncTasks, preTask *syncTask, unstructuredObj *unstructured.Unstructured) syncTasks {
+	modified, err := sc.namespaceModifier(unstructuredObj)
+	if err != nil {
+		tasks = sc.appendFailedNsTask(tasks, unstructuredObj, fmt.Errorf("namespaceModifier error: %s", err))
+	} else if modified {
+		tasks = append(tasks, preTask)
+	}
+
+	return tasks
+}
+
+func (sc *syncContext) appendFailedNsTask(tasks syncTasks, unstructuredObj *unstructured.Unstructured, err error) syncTasks {
+	task := &syncTask{phase: common.SyncPhasePreSync, targetObj: unstructuredObj}
+	sc.setResourceResult(task, common.ResultCodeSyncFailed, common.OperationError, err.Error())
+	tasks = append(tasks, task)
 	return tasks
 }
 

--- a/pkg/sync/sync_context_test.go
+++ b/pkg/sync/sync_context_test.go
@@ -1,9 +1,12 @@
 package sync
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
@@ -35,7 +38,7 @@ import (
 
 var standardVerbs = v1.Verbs{"create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"}
 
-func newTestSyncCtx(opts ...SyncOpt) *syncContext {
+func newTestSyncCtx(getResourceFunc *func(ctx context.Context, config *rest.Config, gvk schema.GroupVersionKind, name string, namespace string) (*unstructured.Unstructured, error), opts ...SyncOpt) *syncContext {
 	fakeDisco := &fakedisco.FakeDiscovery{Fake: &testcore.Fake{}}
 	fakeDisco.Resources = append(make([]*v1.APIResourceList, 0),
 		&v1.APIResourceList{
@@ -67,6 +70,9 @@ func newTestSyncCtx(opts ...SyncOpt) *syncContext {
 		return nil
 	}
 	mockKubectl := kubetest.MockKubectlCmd{}
+	if getResourceFunc != nil {
+		mockKubectl.WithGetResourceFunc(*getResourceFunc)
+	}
 	sc.kubectl = &mockKubectl
 	sc.resourceOps = &mockKubectl
 	for _, opt := range opts {
@@ -77,7 +83,7 @@ func newTestSyncCtx(opts ...SyncOpt) *syncContext {
 
 // make sure Validate means we don't validate
 func TestSyncValidate(t *testing.T) {
-	syncCtx := newTestSyncCtx()
+	syncCtx := newTestSyncCtx(nil)
 	pod := NewPod()
 	pod.SetNamespace("fake-argocd-ns")
 	syncCtx.resources = groupResources(ReconciliationResult{
@@ -93,7 +99,7 @@ func TestSyncValidate(t *testing.T) {
 }
 
 func TestSyncNotPermittedNamespace(t *testing.T) {
-	syncCtx := newTestSyncCtx(WithPermissionValidator(func(un *unstructured.Unstructured, res *v1.APIResource) error {
+	syncCtx := newTestSyncCtx(nil, WithPermissionValidator(func(un *unstructured.Unstructured, res *v1.APIResource) error {
 		return fmt.Errorf("not permitted in project")
 	}))
 	targetPod := NewPod()
@@ -109,7 +115,7 @@ func TestSyncNotPermittedNamespace(t *testing.T) {
 }
 
 func TestSyncCreateInSortedOrder(t *testing.T) {
-	syncCtx := newTestSyncCtx()
+	syncCtx := newTestSyncCtx(nil)
 	syncCtx.resources = groupResources(ReconciliationResult{
 		Live:   []*unstructured.Unstructured{nil, nil},
 		Target: []*unstructured.Unstructured{NewPod(), NewService()},
@@ -171,7 +177,7 @@ func TestSyncCustomResources(t *testing.T) {
 				knownCustomResourceTypes = append(knownCustomResourceTypes, v1.APIResource{Kind: "TestCrd", Group: "argoproj.io", Version: "v1", Namespaced: true, Verbs: standardVerbs})
 			}
 
-			syncCtx := newTestSyncCtx()
+			syncCtx := newTestSyncCtx(nil)
 			fakeDisco := syncCtx.disco.(*fakedisco.FakeDiscovery)
 			fakeDisco.Resources = []*v1.APIResourceList{{
 				GroupVersion: "argoproj.io/v1",
@@ -233,7 +239,7 @@ func TestSyncCustomResources(t *testing.T) {
 }
 
 func TestSyncSuccessfully(t *testing.T) {
-	syncCtx := newTestSyncCtx(WithOperationSettings(false, true, false, false))
+	syncCtx := newTestSyncCtx(nil, WithOperationSettings(false, true, false, false))
 	pod := NewPod()
 	pod.SetNamespace(FakeArgoCDNamespace)
 	syncCtx.resources = groupResources(ReconciliationResult{
@@ -261,7 +267,7 @@ func TestSyncSuccessfully(t *testing.T) {
 }
 
 func TestSyncDeleteSuccessfully(t *testing.T) {
-	syncCtx := newTestSyncCtx(WithOperationSettings(false, true, false, false))
+	syncCtx := newTestSyncCtx(nil, WithOperationSettings(false, true, false, false))
 	svc := NewService()
 	svc.SetNamespace(FakeArgoCDNamespace)
 	pod := NewPod()
@@ -290,7 +296,7 @@ func TestSyncDeleteSuccessfully(t *testing.T) {
 }
 
 func TestSyncCreateFailure(t *testing.T) {
-	syncCtx := newTestSyncCtx()
+	syncCtx := newTestSyncCtx(nil)
 	testSvc := NewService()
 	mockKubectl := &kubetest.MockKubectlCmd{
 		Commands: map[string]kubetest.KubectlOutput{
@@ -324,7 +330,7 @@ func TestSync_ApplyOutOfSyncOnly(t *testing.T) {
 	pod3 := NewPod()
 	pod3.SetName("pod-3")
 
-	syncCtx := newTestSyncCtx()
+	syncCtx := newTestSyncCtx(nil)
 	syncCtx.applyOutOfSyncOnly = true
 	t.Run("modificationResult=nil", func(t *testing.T) {
 		syncCtx.modificationResult = nil
@@ -339,7 +345,7 @@ func TestSync_ApplyOutOfSyncOnly(t *testing.T) {
 		assert.Len(t, resources, 3)
 	})
 
-	syncCtx = newTestSyncCtx(WithResourceModificationChecker(true, diffResultList()))
+	syncCtx = newTestSyncCtx(nil, WithResourceModificationChecker(true, diffResultList()))
 	t.Run("applyOutOfSyncOnly=true", func(t *testing.T) {
 		syncCtx.resources = groupResources(ReconciliationResult{
 			Live:   []*unstructured.Unstructured{nil, pod2, pod3},
@@ -377,7 +383,7 @@ func TestSync_ApplyOutOfSyncOnly(t *testing.T) {
 	})
 
 	t.Run("applyOutOfSyncOnly=true and prune=true", func(t *testing.T) {
-		syncCtx = newTestSyncCtx(WithResourceModificationChecker(true, diffResultList()))
+		syncCtx = newTestSyncCtx(nil, WithResourceModificationChecker(true, diffResultList()))
 		syncCtx.applyOutOfSyncOnly = true
 		syncCtx.prune = true
 		syncCtx.resources = groupResources(ReconciliationResult{
@@ -402,7 +408,7 @@ func TestSync_ApplyOutOfSyncOnly(t *testing.T) {
 	})
 
 	t.Run("applyOutOfSyncOnly=true and syncwaves", func(t *testing.T) {
-		syncCtx = newTestSyncCtx(WithResourceModificationChecker(true, diffResultList()))
+		syncCtx = newTestSyncCtx(nil, WithResourceModificationChecker(true, diffResultList()))
 		syncCtx.applyOutOfSyncOnly = true
 		syncCtx.prune = true
 		pod1.SetAnnotations(map[string]string{synccommon.AnnotationSyncWave: "2"})
@@ -433,7 +439,7 @@ func TestSync_ApplyOutOfSyncOnly(t *testing.T) {
 }
 
 func TestSyncPruneFailure(t *testing.T) {
-	syncCtx := newTestSyncCtx(WithOperationSettings(false, true, false, false))
+	syncCtx := newTestSyncCtx(nil, WithOperationSettings(false, true, false, false))
 	mockKubectl := &kubetest.MockKubectlCmd{
 		Commands: map[string]kubetest.KubectlOutput{
 			"test-service": {
@@ -519,7 +525,7 @@ func TestServerResourcesRetry(t *testing.T) {
 	}
 	setup := func(t *testing.T, apiFailuresCount int) *fixture {
 		t.Helper()
-		syncCtx := newTestSyncCtx(WithOperationSettings(false, false, false, true))
+		syncCtx := newTestSyncCtx(nil, WithOperationSettings(false, false, false, true))
 
 		unauthorizedStatus := &metav1.Status{
 			Status:  metav1.StatusFailure,
@@ -647,7 +653,7 @@ func TestServerResourcesRetry(t *testing.T) {
 }
 
 func TestDoNotSyncOrPruneHooks(t *testing.T) {
-	syncCtx := newTestSyncCtx(WithOperationSettings(false, false, false, true))
+	syncCtx := newTestSyncCtx(nil, WithOperationSettings(false, false, false, true))
 	targetPod := NewPod()
 	targetPod.SetName("do-not-create-me")
 	targetPod.SetAnnotations(map[string]string{synccommon.AnnotationKeyHook: "PreSync"})
@@ -665,7 +671,7 @@ func TestDoNotSyncOrPruneHooks(t *testing.T) {
 
 // make sure that we do not prune resources with Prune=false
 func TestDoNotPrunePruneFalse(t *testing.T) {
-	syncCtx := newTestSyncCtx(WithOperationSettings(false, true, false, false))
+	syncCtx := newTestSyncCtx(nil, WithOperationSettings(false, true, false, false))
 	pod := NewPod()
 	pod.SetAnnotations(map[string]string{synccommon.AnnotationSyncOptions: "Prune=false"})
 	pod.SetNamespace(FakeArgoCDNamespace)
@@ -701,7 +707,7 @@ func TestSyncOptionValidate(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			syncCtx := newTestSyncCtx()
+			syncCtx := newTestSyncCtx(nil)
 			pod := NewPod()
 			pod.SetAnnotations(map[string]string{synccommon.AnnotationSyncOptions: tt.annotationVal})
 			pod.SetNamespace(FakeArgoCDNamespace)
@@ -737,7 +743,7 @@ func TestSync_Replace(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			syncCtx := newTestSyncCtx()
+			syncCtx := newTestSyncCtx(nil)
 
 			tc.target.SetNamespace(FakeArgoCDNamespace)
 			if tc.live != nil {
@@ -785,7 +791,7 @@ func TestSync_ServerSideApply(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			syncCtx := newTestSyncCtx()
+			syncCtx := newTestSyncCtx(nil)
 			syncCtx.serverSideApplyManager = tc.manager
 
 			tc.target.SetNamespace(FakeArgoCDNamespace)
@@ -812,7 +818,7 @@ func TestSelectiveSyncOnly(t *testing.T) {
 	pod1.SetName("pod-1")
 	pod2 := NewPod()
 	pod2.SetName("pod-2")
-	syncCtx := newTestSyncCtx(WithResourcesFilter(func(key kube.ResourceKey, _ *unstructured.Unstructured, _ *unstructured.Unstructured) bool {
+	syncCtx := newTestSyncCtx(nil, WithResourcesFilter(func(key kube.ResourceKey, _ *unstructured.Unstructured, _ *unstructured.Unstructured) bool {
 		return key.Kind == pod1.GetKind() && key.Name == pod1.GetName()
 	}))
 	syncCtx.resources = groupResources(ReconciliationResult{
@@ -828,7 +834,7 @@ func TestSelectiveSyncOnly(t *testing.T) {
 
 func TestUnnamedHooksGetUniqueNames(t *testing.T) {
 	t.Run("Truncated revision", func(t *testing.T) {
-		syncCtx := newTestSyncCtx()
+		syncCtx := newTestSyncCtx(nil)
 
 		pod := NewPod()
 		pod.SetName("")
@@ -845,7 +851,7 @@ func TestUnnamedHooksGetUniqueNames(t *testing.T) {
 	})
 
 	t.Run("Short revision", func(t *testing.T) {
-		syncCtx := newTestSyncCtx()
+		syncCtx := newTestSyncCtx(nil)
 		pod := NewPod()
 		pod.SetName("")
 		pod.SetAnnotations(map[string]string{synccommon.AnnotationKeyHook: "PreSync,PostSync"})
@@ -862,7 +868,7 @@ func TestUnnamedHooksGetUniqueNames(t *testing.T) {
 }
 
 func TestManagedResourceAreNotNamed(t *testing.T) {
-	syncCtx := newTestSyncCtx()
+	syncCtx := newTestSyncCtx(nil)
 	pod := NewPod()
 	pod.SetName("")
 
@@ -880,7 +886,7 @@ func TestManagedResourceAreNotNamed(t *testing.T) {
 }
 
 func TestDeDupingTasks(t *testing.T) {
-	syncCtx := newTestSyncCtx(WithOperationSettings(false, true, false, false))
+	syncCtx := newTestSyncCtx(nil, WithOperationSettings(false, true, false, false))
 	pod := NewPod()
 	pod.SetAnnotations(map[string]string{synccommon.AnnotationKeyHook: "Sync"})
 	syncCtx.resources = groupResources(ReconciliationResult{
@@ -896,7 +902,7 @@ func TestDeDupingTasks(t *testing.T) {
 }
 
 func TestObjectsGetANamespace(t *testing.T) {
-	syncCtx := newTestSyncCtx()
+	syncCtx := newTestSyncCtx(nil)
 	pod := NewPod()
 	syncCtx.resources = groupResources(ReconciliationResult{
 		Live:   []*unstructured.Unstructured{nil},
@@ -914,7 +920,7 @@ func TestObjectsGetANamespace(t *testing.T) {
 func TestNamespaceAutoCreation(t *testing.T) {
 	pod := NewPod()
 	namespace := NewNamespace()
-	syncCtx := newTestSyncCtx()
+	syncCtx := newTestSyncCtx(nil)
 	syncCtx.createNamespace = true
 	syncCtx.namespace = FakeArgoCDNamespace
 	namespace.SetName(FakeArgoCDNamespace)
@@ -982,6 +988,54 @@ func TestNamespaceAutoCreation(t *testing.T) {
 
 }
 
+func TestNamespaceAutoCreationForNotExistNs(t *testing.T) {
+	getResourceFunc := func(ctx context.Context, config *rest.Config, gvk schema.GroupVersionKind, name string, namespace string) (*unstructured.Unstructured, error) {
+		return nil, apierrors.NewNotFound(schema.GroupResource{}, FakeArgoCDNamespace)
+	}
+
+	pod := NewPod()
+	namespace := NewNamespace()
+	syncCtx := newTestSyncCtx(&getResourceFunc)
+	syncCtx.createNamespace = true
+	syncCtx.namespace = FakeArgoCDNamespace
+	namespace.SetName(FakeArgoCDNamespace)
+
+	t.Run("pre-sync task should exist and namespace creator should be called", func(t *testing.T) {
+		syncCtx.resources = groupResources(ReconciliationResult{
+			Live:   []*unstructured.Unstructured{nil},
+			Target: []*unstructured.Unstructured{pod},
+		})
+		creatorCalled := false
+		syncCtx.namespaceCreator = func(*unstructured.Unstructured) bool {
+			creatorCalled = true
+			return true
+		}
+		tasks, successful := syncCtx.getSyncTasks()
+
+		assert.True(t, creatorCalled)
+		assert.True(t, successful)
+		assert.Len(t, tasks, 2)
+	})
+
+	t.Run("pre-sync task should be not created and namespace creator should be called", func(t *testing.T) {
+		syncCtx.resources = groupResources(ReconciliationResult{
+			Live:   []*unstructured.Unstructured{nil},
+			Target: []*unstructured.Unstructured{pod},
+		})
+		creatorCalled := false
+		syncCtx.namespaceCreator = func(*unstructured.Unstructured) bool {
+			creatorCalled = true
+			return false
+		}
+		tasks, successful := syncCtx.getSyncTasks()
+
+		assert.True(t, creatorCalled)
+		assert.True(t, successful)
+		assert.Len(t, tasks, 1)
+	})
+
+}
+
 func createNamespaceTask(namespace string) (*syncTask, error) {
 	nsSpec := &corev1.Namespace{TypeMeta: v1.TypeMeta{APIVersion: "v1", Kind: kube.NamespaceKind}, ObjectMeta: v1.ObjectMeta{Name: namespace}}
 	unstructuredObj, err := kube.ToUnstructured(nsSpec)
@@ -991,7 +1045,7 @@ func createNamespaceTask(namespace string) (*syncTask, error) {
 }
 
 func TestSyncFailureHookWithSuccessfulSync(t *testing.T) {
-	syncCtx := newTestSyncCtx()
+	syncCtx := newTestSyncCtx(nil)
 	syncCtx.resources = groupResources(ReconciliationResult{
 		Live:   []*unstructured.Unstructured{nil},
 		Target: []*unstructured.Unstructured{NewPod()},
@@ -1006,7 +1060,7 @@ func TestSyncFailureHookWithSuccessfulSync(t *testing.T) {
 }
 
 func TestSyncFailureHookWithFailedSync(t *testing.T) {
-	syncCtx := newTestSyncCtx()
+	syncCtx := newTestSyncCtx(nil)
 	pod := NewPod()
 	syncCtx.resources = groupResources(ReconciliationResult{
 		Live:   []*unstructured.Unstructured{nil},
@@ -1028,7 +1082,7 @@ func TestSyncFailureHookWithFailedSync(t *testing.T) {
 }
 
 func TestBeforeHookCreation(t *testing.T) {
-	syncCtx := newTestSyncCtx()
+	syncCtx := newTestSyncCtx(nil)
 	hook := Annotate(Annotate(NewPod(), synccommon.AnnotationKeyHook, "Sync"), synccommon.AnnotationKeyHookDeletePolicy, "BeforeHookCreation")
 	hook.SetNamespace(FakeArgoCDNamespace)
 	syncCtx.resources = groupResources(ReconciliationResult{
@@ -1049,7 +1103,7 @@ func TestBeforeHookCreation(t *testing.T) {
 func TestRunSyncFailHooksFailed(t *testing.T) {
 	// Tests that other SyncFail Hooks run even if one of them fail.
 
-	syncCtx := newTestSyncCtx()
+	syncCtx := newTestSyncCtx(nil)
 	pod := NewPod()
 	successfulSyncFailHook := newHook(synccommon.HookTypeSyncFail)
 	successfulSyncFailHook.SetName("successful-sync-fail-hook")
@@ -1105,7 +1159,7 @@ func TestRunSync_HooksNotDeletedIfPhaseNotCompleted(t *testing.T) {
 	inProgressHook.SetName("in-progress-hook")
 	_ = Annotate(inProgressHook, synccommon.AnnotationKeyHookDeletePolicy, "HookSucceeded")
 
-	syncCtx := newTestSyncCtx(
+	syncCtx := newTestSyncCtx(nil,
 		WithHealthOverride(resourceNameHealthOverride(map[string]health.HealthStatusCode{
 			inProgressHook.GetName(): health.HealthStatusProgressing,
 		})),
@@ -1154,7 +1208,7 @@ func TestRunSync_HooksDeletedAfterPhaseCompleted(t *testing.T) {
 	completedHook2.SetName("completed-hook2")
 	_ = Annotate(completedHook2, synccommon.AnnotationKeyHookDeletePolicy, "HookSucceeded")
 
-	syncCtx := newTestSyncCtx(
+	syncCtx := newTestSyncCtx(nil,
 		WithInitialState(synccommon.OperationRunning, "", []synccommon.ResourceSyncResult{{
 			ResourceKey: kube.GetResourceKey(completedHook1),
 			HookPhase:   synccommon.OperationSucceeded,
@@ -1200,7 +1254,7 @@ func TestRunSync_HooksDeletedAfterPhaseCompletedFailed(t *testing.T) {
 	completedHook2.SetName("completed-hook2")
 	_ = Annotate(completedHook2, synccommon.AnnotationKeyHookDeletePolicy, "HookFailed")
 
-	syncCtx := newTestSyncCtx(
+	syncCtx := newTestSyncCtx(nil,
 		WithInitialState(synccommon.OperationRunning, "", []synccommon.ResourceSyncResult{{
 			ResourceKey: kube.GetResourceKey(completedHook1),
 			HookPhase:   synccommon.OperationSucceeded,
@@ -1313,7 +1367,7 @@ func Test_setRunningPhase_pendingDeletion(t *testing.T) {
 }
 
 func TestSyncWaveHook(t *testing.T) {
-	syncCtx := newTestSyncCtx(WithOperationSettings(false, false, false, false))
+	syncCtx := newTestSyncCtx(nil, WithOperationSettings(false, false, false, false))
 	pod1 := NewPod()
 	pod1.SetName("pod-1")
 	pod1.SetAnnotations(map[string]string{synccommon.AnnotationSyncWave: "-1"})
@@ -1384,7 +1438,7 @@ func TestSyncWaveHook(t *testing.T) {
 }
 
 func TestSyncWaveHookFail(t *testing.T) {
-	syncCtx := newTestSyncCtx(WithOperationSettings(false, false, false, false))
+	syncCtx := newTestSyncCtx(nil, WithOperationSettings(false, false, false, false))
 	pod1 := NewPod()
 	pod1.SetName("pod-1")
 
@@ -1407,7 +1461,7 @@ func TestSyncWaveHookFail(t *testing.T) {
 }
 
 func TestPruneLast(t *testing.T) {
-	syncCtx := newTestSyncCtx()
+	syncCtx := newTestSyncCtx(nil)
 	syncCtx.pruneLast = true
 
 	pod1 := NewPod()


### PR DESCRIPTION
Rename `WithNamespaceCreation` to `WithNamespaceModifier`, since this
method is also used for modifying existing namespaces. This method
takes a single argument for the actual updating, and unless this method
gets invoked by its caller no updating will take place (fulfilling what
the `createNamespace` argument used to do).

Within `autoCreateNamespace`, everywhere where we previously added tasks
we'll now need to check whether the namespace should be created (or
modified), which is now delegated to the `appendNsTask` and
`appendFailedNsTask` methods.
