### PR TITLE
fix: hook lifecycle was flaky

### DIFF
--- a/pkg/sync/sync_tasks.go
+++ b/pkg/sync/sync_tasks.go
@@ -272,6 +272,7 @@ func (s syncTasks) lastWave() int {
 	return 0
 }
 
-func (s syncTasks) multiStep() bool {
+// hasMoreSteps returns if there is going to be a later wave or sync phase from the current one
+func (s syncTasks) hasMoreSteps() bool {
 	return s.wave() != s.lastWave() || s.phase() != s.lastPhase()
 }

--- a/pkg/sync/sync_tasks_test.go
+++ b/pkg/sync/sync_tasks_test.go
@@ -457,14 +457,14 @@ func TestSyncTasksSort_CRDAndCR(t *testing.T) {
 	assert.Equal(t, syncTasks{crd, cr}, unsorted)
 }
 
-func Test_syncTasks_multiStep(t *testing.T) {
+func Test_syncTasks_hasMoreSteps(t *testing.T) {
 	t.Run("Single", func(t *testing.T) {
 		tasks := syncTasks{{liveObj: Annotate(NewPod(), common.AnnotationSyncWave, "-1"), phase: common.SyncPhaseSync}}
 		assert.Equal(t, common.SyncPhaseSync, string(tasks.phase()))
 		assert.Equal(t, -1, tasks.wave())
 		assert.Equal(t, common.SyncPhaseSync, string(tasks.lastPhase()))
 		assert.Equal(t, -1, tasks.lastWave())
-		assert.False(t, tasks.multiStep())
+		assert.False(t, tasks.hasMoreSteps())
 	})
 	t.Run("Double", func(t *testing.T) {
 		tasks := syncTasks{
@@ -475,6 +475,6 @@ func Test_syncTasks_multiStep(t *testing.T) {
 		assert.Equal(t, -1, tasks.wave())
 		assert.Equal(t, common.SyncPhasePostSync, string(tasks.lastPhase()))
 		assert.Equal(t, 1, tasks.lastWave())
-		assert.True(t, tasks.multiStep())
+		assert.True(t, tasks.hasMoreSteps())
 	})
 }


### PR DESCRIPTION
Occasionally hooks such as a PreSyncHook which had `hook-delete-policy: before-hook-creation` could get into a situation where the hook was forever stuck in "Pending deletion".

This reworks the sync logic slightly such that we allow the Sync() logic to progress further down the method, into the portion of code that handles hook lifecycle. By doing so, we will realize when a hook's lifecycle needs to be managed (deleted/created/etc...)

This is still being tested fully.

Signed-off-by: Jesse Suen <jesse@akuity.io>