### PR TITLE
feat: Add sync-dependencies

### DIFF
--- a/pkg/sync/common/types.go
+++ b/pkg/sync/common/types.go
@@ -12,6 +12,13 @@ const (
 	AnnotationSyncOptions = "argocd.argoproj.io/sync-options"
 	// AnnotationSyncWave indicates which wave of the sync the resource or hook should be in
 	AnnotationSyncWave = "argocd.argoproj.io/sync-wave"
+	// AnnotationSyncDependencies is dependencies of this object
+	// The dependencies are specified as a comma-separated list of objects.
+	// The format of each object is <group>/<kind>/<namespace>/<name>
+	// The group and kind are optional. If not specified, they'll match any group or kind.
+	// The namespace is optional. If not specified, the namespace is assumed to be the same as the namespace of the object.
+	// The name is required.
+	AnnotationSyncDependencies = "argocd.argoproj.io/sync-dependencies"
 	// AnnotationKeyHook contains the hook type of a resource
 	AnnotationKeyHook = "argocd.argoproj.io/hook"
 	// AnnotationKeyHookDeletePolicy is the policy of deleting a hook

--- a/pkg/sync/sync_context.go
+++ b/pkg/sync/sync_context.go
@@ -500,34 +500,22 @@ func (sc *syncContext) Sync() {
 	wave := tasks.wave()
 	finalWave := phase == tasks.lastPhase() && wave == tasks.lastWave()
 
-	// if it is the last phase/wave and the only remaining tasks are non-hooks, then we are successful
-	// EVEN if those objects subsequently degraded
-	// This handles the common case where neither hooks or waves are used and a sync equates to simply an (asynchronous) kubectl apply of manifests, which succeeds immediately.
-	tasks, waitingTasks := tasks.Split(func(t *syncTask) bool {
+	hasIncompleteDependency := func(t *syncTask) bool {
 		for _, dep := range t.dependencies() {
-			if !completedTasks.All(func(t *syncTask) bool { return dep.match(t.obj()) }) {
-				t.message = fmt.Sprintf("waiting for dependency %s to complete", dep)
-				return false
+			if !completedTasks.Any(func(t *syncTask) bool { return dep.match(t.obj()) }) {
+				return true
 			}
 		}
-		if t.phase != phase {
-			t.message = fmt.Sprintf("waiting for phase %s to complete", t.phase)
-			return false
-		}
-		if t.wave() != wave {
-			t.message = fmt.Sprintf("waiting for sync was %d to complete", t.wave())
-			return false
-		}
-		return true
-	})
-	sc.log.WithValues("phase", phase, "wave", wave, "tasks", tasks, "waitingTasks", waitingTasks, "syncFailTasks", syncFailTasks).V(1).Info("Filtering tasks in correct phase and wave")
-
-	// set the message for all waiting tasks, so that the user can understand why nothing is happening
-	for _, task := range waitingTasks {
-		sc.setResourceResult(task, "", "", task.message)
+		return false
 	}
 
-	sc.setOperationPhase(common.OperationRunning, "one or more tasks are running")
+	tasks, waitingTasks := tasks.Split(func(t *syncTask) bool {
+		return t.phase == phase && t.wave() == wave && !hasIncompleteDependency(t)
+	})
+
+	sc.log.WithValues("phase", phase, "wave", wave, "tasks", tasks, "waitingTasks", waitingTasks, "syncFailTasks", syncFailTasks).V(1).Info("Filtering tasks in correct phase and wave")
+
+	sc.setOperationPhase(common.OperationRunning, fmt.Sprintf("%d task(s) are running", len(tasks)))
 
 	sc.log.WithValues("tasks", tasks).V(1).Info("Wet-run")
 	runState := sc.runTasks(tasks, false)
@@ -548,7 +536,14 @@ func (sc *syncContext) Sync() {
 		sc.deleteHooks(hooksPendingDeletionFailed)
 		sc.setOperationFailed(syncFailTasks, syncFailedTasks, "one or more objects failed to apply")
 	case successful:
-		if waitingTasks.Len() == 0 {
+
+		// if it is the last phase/wave and the only remaining tasks are non-hooks, then the sync is complete
+		// EVEN if those objects subsequently degraded
+		// This handles the case where neither hooks or waves are used and a sync equates to an
+		// (asynchronous) kubectl apply of manifests, which succeeds immediately.
+		anyHooks := tasks.Any(func(task *syncTask) bool { return task.isHook() })
+
+		if len(waitingTasks) == 0 && !anyHooks {
 			// delete all completed hooks which have appropriate delete policy
 			sc.deleteHooks(hooksPendingDeletionSuccessful)
 			sc.setOperationPhase(common.OperationSucceeded, "successfully synced (all tasks run)")

--- a/pkg/sync/sync_context_test.go
+++ b/pkg/sync/sync_context_test.go
@@ -1082,7 +1082,6 @@ func TestNamespaceAutoCreationForNonExistingNs(t *testing.T) {
 			syncStatus:     synccommon.ResultCodeSyncFailed,
 			operationState: synccommon.OperationError,
 			message:        "namespaceModifier error: some error",
-			waveOverride:   nil,
 		}, tasks[0])
 	})
 }
@@ -1133,6 +1132,7 @@ func TestSyncFailureHookWithFailedSync(t *testing.T) {
 }
 
 func TestBeforeHookCreation(t *testing.T) {
+	t.SkipNow()
 	syncCtx := newTestSyncCtx(nil)
 	hook := Annotate(Annotate(NewPod(), synccommon.AnnotationKeyHook, "Sync"), synccommon.AnnotationKeyHookDeletePolicy, "BeforeHookCreation")
 	hook.SetNamespace(FakeArgoCDNamespace)

--- a/pkg/sync/sync_context_test.go
+++ b/pkg/sync/sync_context_test.go
@@ -1132,7 +1132,6 @@ func TestSyncFailureHookWithFailedSync(t *testing.T) {
 }
 
 func TestBeforeHookCreation(t *testing.T) {
-	t.SkipNow()
 	syncCtx := newTestSyncCtx(nil)
 	hook := Annotate(Annotate(NewPod(), synccommon.AnnotationKeyHook, "Sync"), synccommon.AnnotationKeyHookDeletePolicy, "BeforeHookCreation")
 	hook.SetNamespace(FakeArgoCDNamespace)

--- a/pkg/sync/sync_task.go
+++ b/pkg/sync/sync_task.go
@@ -2,10 +2,9 @@ package sync
 
 import (
 	"fmt"
-	"strings"
-
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"strings"
 
 	"github.com/argoproj/gitops-engine/pkg/sync/common"
 	"github.com/argoproj/gitops-engine/pkg/sync/hook"
@@ -57,6 +56,10 @@ func (t *syncTask) obj() *unstructured.Unstructured {
 	return obj(t.targetObj, t.liveObj)
 }
 
+func (t *syncTask) wave() int {
+	return syncwaves.Wave(t.obj())
+}
+
 // Returns the dependencies of the task.
 func (t *syncTask) dependencies() []taskDependency {
 	var out []taskDependency
@@ -81,10 +84,6 @@ func (t *syncTask) dependencies() []taskDependency {
 		}
 	}
 	return out
-}
-
-func (t *syncTask) wave() int {
-	return syncwaves.Wave(t.obj())
 }
 
 func (t *syncTask) isHook() bool {

--- a/pkg/sync/sync_tasks.go
+++ b/pkg/sync/sync_tasks.go
@@ -207,6 +207,7 @@ func (s syncTasks) String() string {
 	return "[" + strings.Join(values, ", ") + "]"
 }
 
+// names returns the names of the tasks
 func (s syncTasks) names() []string {
 	var values []string
 	for _, task := range s {

--- a/pkg/sync/task_dependency.go
+++ b/pkg/sync/task_dependency.go
@@ -1,0 +1,20 @@
+package sync
+
+import (
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"strings"
+)
+
+type taskDependency struct {
+	Namespace string
+	Name      string
+	Kind      string
+	Group     string
+}
+
+func (d taskDependency) match(obj *unstructured.Unstructured) bool {
+	return (obj.GetKind() == d.Kind || d.Kind == "") &&
+		(strings.HasPrefix(obj.GetAPIVersion(), d.Group+"/") || d.Group == "") &&
+		(obj.GetNamespace() == d.Namespace || d.Namespace == "") &&
+		(obj.GetGenerateName() == d.Name || obj.GetName() == d.Name || d.Name == "")
+}

--- a/pkg/sync/task_dependency.go
+++ b/pkg/sync/task_dependency.go
@@ -12,6 +12,7 @@ type taskDependency struct {
 	Group     string
 }
 
+// match returns true if the given object matches the dependency
 func (d taskDependency) match(obj *unstructured.Unstructured) bool {
 	return (obj.GetKind() == d.Kind || d.Kind == "") &&
 		(strings.HasPrefix(obj.GetAPIVersion(), d.Group+"/") || d.Group == "") &&

--- a/pkg/sync/task_dependency_test.go
+++ b/pkg/sync/task_dependency_test.go
@@ -1,0 +1,33 @@
+package sync
+
+import (
+	testingutils "github.com/argoproj/gitops-engine/pkg/utils/testing"
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"testing"
+)
+
+func Test_taskDependency_match(t *testing.T) {
+	tests := []struct {
+		name    string
+		taskDep taskDependency
+		obj     *unstructured.Unstructured
+		want    bool
+	}{
+		{"name/mismatch", taskDependency{Name: "foo"}, testingutils.Unstructured(`{"kind": "Pod", "metadata": {"name": "bar"}}`), false},
+		{"name/match", taskDependency{Name: "foo"}, testingutils.Unstructured(`{"kind": "Pod", "metadata": {"name": "foo"}}`), true},
+		{"generateName/mismatch", taskDependency{Name: "foo"}, testingutils.Unstructured(`{"kind": "Pod", "metadata": {"generateName": "bar"}}`), false},
+		{"generateName/match", taskDependency{Name: "foo"}, testingutils.Unstructured(`{"kind": "Pod", "metadata": {"generateName": "foo"}}`), true},
+		{"namespace/mismatch", taskDependency{Namespace: "bar"}, testingutils.Unstructured(`{"kind": "Pod"}`), false},
+		{"namespace/match", taskDependency{Namespace: "bar"}, testingutils.Unstructured(`{"kind": "Pod", "metadata": {"namespace": "bar"}}`), true},
+		{"kind/mismatch", taskDependency{Kind: "no"}, testingutils.Unstructured(`{"kind": "Pod"}`), false},
+		{"kind/match", taskDependency{Kind: "Pod"}, testingutils.Unstructured(`{"kind": "Pod"}`), true},
+		{"group/mismatch", taskDependency{Group: "no"}, testingutils.Unstructured(`{"kind": "Pod"}`), false},
+		{"group/match", taskDependency{Group: "core"}, testingutils.Unstructured(`{"kind": "Pod", "apiVersion": "core/v1"}`), true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equalf(t, tt.want, tt.taskDep.match(tt.obj), "match(%v)", tt.obj)
+		})
+	}
+}

--- a/pkg/utils/testing/testdata.go
+++ b/pkg/utils/testing/testdata.go
@@ -12,6 +12,11 @@ func HelmHook(obj *unstructured.Unstructured, hookType string) *unstructured.Uns
 	return Annotate(obj, "helm.sh/hook", hookType)
 }
 
+func Name(obj *unstructured.Unstructured, name string) *unstructured.Unstructured {
+	obj.SetName(name)
+	return obj
+}
+
 func Annotate(obj *unstructured.Unstructured, key, val string) *unstructured.Unstructured {
 	annotations := obj.GetAnnotations()
 	if annotations == nil {


### PR DESCRIPTION
Depended on by [argo-cd#3517](https://github.com/argoproj/argo-cd/issues/3517)

This PR introduces a new feature: sync dependencies.

Sync dependencies give a new way to order sync operations that is influenced by sync waves and sync hooks (all of which I wrote, so I know it extremely well). 

Like sync waves, a sync operation will only progress when all the dependents have completed. 

Dependencies between objects is specified by the new `argocd.argoproj.io/sync-dependencies` annotation. 

```yaml
# The dependencies are specified as a comma-separated list of objects.
# The format of each object is <group>/<kind>/<namespace>/<name>
# The group and kind are optional. If not specified, they'll match any group or kind.
# The namespace is optional. If not specified, the namespace is assumed to be the same as the namespace of the object.
# The name is required.
argocd.argoproj.io/sync-dependencies: a,b,c
```

Reasons to do this:

* The 3rd most popular enhancement request for Argo CD
* Explanation can be found in [argo-cd#3517](https://github.com/argoproj/argo-cd/issues/3517).
* Implementation is contained within the GitOps engine.

Reasons not to do this:

* Impacts core GitOps engine code (must be mitigated by exceptional testing).
* Another gun to shoot yourself in the foot with.

Open questions:

* Sync waves, hooks, and dependencies have a certain level of opacity to them. By which I mean, that it is not always clear what they're doing unless you're familiar with the app. I wonder if we should introduce a new "waiting" state for resources?
* Should dependencies take precedence over waves? I think this is yes.
* How should dependencies be described? I've used annotation, is that right? Is that the right structure? 
* Are the rules that match tasks to dependencies?