### PR TITLE
chore: migrate from k8s.gcr.io to registry.k8s.io

### DIFF
--- a/agent/manifests/base/gitops-agent-deploy.yaml
+++ b/agent/manifests/base/gitops-agent-deploy.yaml
@@ -35,7 +35,7 @@ spec:
             - http://localhost:9001/api/v1/sync
             - --dest
             - repo
-          image: k8s.gcr.io/git-sync:v3.1.6
+          image: registry.k8s.io/git-sync:v3.1.6
           volumeMounts:
             - name: git
               mountPath: /tmp/git

--- a/agent/manifests/install-namespaced.yaml
+++ b/agent/manifests/install-namespaced.yaml
@@ -8,12 +8,12 @@ kind: Role
 metadata:
   name: gitops-agent
 rules:
-- apiGroups:
-  - '*'
-  resources:
-  - '*'
-  verbs:
-  - '*'
+  - apiGroups:
+      - "*"
+    resources:
+      - "*"
+    verbs:
+      - "*"
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -24,8 +24,8 @@ roleRef:
   kind: Role
   name: gitops-agent
 subjects:
-- kind: ServiceAccount
-  name: gitops-agent
+  - kind: ServiceAccount
+    name: gitops-agent
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -43,31 +43,31 @@ spec:
         app.kubernetes.io/name: gitops-agent
     spec:
       containers:
-      - command:
-        - gitops
-        - /tmp/git/repo
-        - --path
-        - guestbook
-        - --namespaced
-        image: argoproj/gitops-agent:latest
-        name: gitops-agent
-        volumeMounts:
-        - mountPath: /tmp/git
-          name: git
-      - args:
-        - --webhook-url
-        - http://localhost:9001/api/v1/sync
-        - --dest
-        - repo
-        env:
-        - name: GIT_SYNC_REPO
-          value: https://github.com/argoproj/argocd-example-apps
-        image: k8s.gcr.io/git-sync:v3.1.6
-        name: git-sync
-        volumeMounts:
-        - mountPath: /tmp/git
-          name: git
+        - command:
+            - gitops
+            - /tmp/git/repo
+            - --path
+            - guestbook
+            - --namespaced
+          image: argoproj/gitops-agent:latest
+          name: gitops-agent
+          volumeMounts:
+            - mountPath: /tmp/git
+              name: git
+        - args:
+            - --webhook-url
+            - http://localhost:9001/api/v1/sync
+            - --dest
+            - repo
+          env:
+            - name: GIT_SYNC_REPO
+              value: https://github.com/argoproj/argocd-example-apps
+          image: registry.k8s.io/git-sync:v3.1.6
+          name: git-sync
+          volumeMounts:
+            - mountPath: /tmp/git
+              name: git
       serviceAccountName: gitops-agent
       volumes:
-      - emptyDir: {}
-        name: git
+        - emptyDir: {}
+          name: git

--- a/agent/manifests/install.yaml
+++ b/agent/manifests/install.yaml
@@ -8,16 +8,16 @@ kind: ClusterRole
 metadata:
   name: gitops-agent
 rules:
-- apiGroups:
-  - '*'
-  resources:
-  - '*'
-  verbs:
-  - '*'
-- nonResourceURLs:
-  - '*'
-  verbs:
-  - '*'
+  - apiGroups:
+      - "*"
+    resources:
+      - "*"
+    verbs:
+      - "*"
+  - nonResourceURLs:
+      - "*"
+    verbs:
+      - "*"
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -28,9 +28,9 @@ roleRef:
   kind: ClusterRole
   name: gitops-agent
 subjects:
-- kind: ServiceAccount
-  name: gitops-agent
-  namespace: gitops-agent
+  - kind: ServiceAccount
+    name: gitops-agent
+    namespace: gitops-agent
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -48,30 +48,30 @@ spec:
         app.kubernetes.io/name: gitops-agent
     spec:
       containers:
-      - command:
-        - gitops
-        - /tmp/git/repo
-        - --path
-        - guestbook
-        image: argoproj/gitops-agent:latest
-        name: gitops-agent
-        volumeMounts:
-        - mountPath: /tmp/git
-          name: git
-      - args:
-        - --webhook-url
-        - http://localhost:9001/api/v1/sync
-        - --dest
-        - repo
-        env:
-        - name: GIT_SYNC_REPO
-          value: https://github.com/argoproj/argocd-example-apps
-        image: k8s.gcr.io/git-sync:v3.1.6
-        name: git-sync
-        volumeMounts:
-        - mountPath: /tmp/git
-          name: git
+        - command:
+            - gitops
+            - /tmp/git/repo
+            - --path
+            - guestbook
+          image: argoproj/gitops-agent:latest
+          name: gitops-agent
+          volumeMounts:
+            - mountPath: /tmp/git
+              name: git
+        - args:
+            - --webhook-url
+            - http://localhost:9001/api/v1/sync
+            - --dest
+            - repo
+          env:
+            - name: GIT_SYNC_REPO
+              value: https://github.com/argoproj/argocd-example-apps
+          image: registry.k8s.io/git-sync:v3.1.6
+          name: git-sync
+          volumeMounts:
+            - mountPath: /tmp/git
+              name: git
       serviceAccountName: gitops-agent
       volumes:
-      - emptyDir: {}
-        name: git
+        - emptyDir: {}
+          name: git


### PR DESCRIPTION
Kubernetes is migrating its image registry from [k8s.gcr.io](http://k8s.gcr.io/) to [registry.k8s.io](http://registry.k8s.io/).

Part of kubernetes/k8s.io#4780.