### PR TITLE
fix: avoid acquiring lock on mutex and semaphore at the same time to prevent deadlock

### DIFF
--- a/pkg/cache/cluster.go
+++ b/pkg/cache/cluster.go
@@ -540,8 +540,8 @@ func (c *clusterCache) watchEvents(ctx context.Context, api kube.APIResourceInfo
 
 		// load API initial state if no resource version provided
 		if resourceVersion == "" {
+			var items []*Resource
 			resourceVersion, err = c.listResources(ctx, resClient, func(listPager *pager.ListPager) error {
-				var items []*Resource
 				err := listPager.EachListItem(ctx, metav1.ListOptions{}, func(obj runtime.Object) error {
 					if un, ok := obj.(*unstructured.Unstructured); !ok {
 						return fmt.Errorf("object %s/%s has an unexpected type", un.GroupVersionKind().String(), un.GetName())
@@ -554,14 +554,17 @@ func (c *clusterCache) watchEvents(ctx context.Context, api kube.APIResourceInfo
 				if err != nil {
 					return fmt.Errorf("failed to load initial state of resource %s: %v", api.GroupKind.String(), err)
 				}
-
-				return runSynced(&c.lock, func() error {
-					c.replaceResourceCache(api.GroupKind, items, ns)
-					return nil
-				})
+				return nil
 			})
 
 			if err != nil {
+				return err
+			}
+
+			if err := runSynced(&c.lock, func() error {
+				c.replaceResourceCache(api.GroupKind, items, ns)
+				return nil
+			}); err != nil {
 				return err
 			}
 		}

--- a/pkg/cache/cluster.go
+++ b/pkg/cache/cluster.go
@@ -561,12 +561,9 @@ func (c *clusterCache) watchEvents(ctx context.Context, api kube.APIResourceInfo
 				return err
 			}
 
-			if err := runSynced(&c.lock, func() error {
-				c.replaceResourceCache(api.GroupKind, items, ns)
-				return nil
-			}); err != nil {
-				return err
-			}
+			c.lock.Lock()
+			c.replaceResourceCache(api.GroupKind, items, ns)
+			c.lock.Unlock()
 		}
 
 		w, err := watchutil.NewRetryWatcher(resourceVersion, &cache.ListWatch{


### PR DESCRIPTION
Closes https://github.com/argoproj/argo-cd/issues/11458

PR fixes deadlock in cluster caching code that causes app controller to stop working suddenly:

Deadlock is triggered by cluster re-syncing and happening because code it trying to acquire mutex and semaphore at the same time:

https://github.com/argoproj/gitops-engine/blob/ed70eac8b7bd6b2f276502398fdbccccab5d189a/pkg/cache/cluster.go#L543

```golang
// listResources acquires semaphore and releases when method exits
resourceVersion, err = c.listResources(ctx, resClient, func(listPager *pager.ListPager) error {
    ...
    // runSynced acquires mutex so listResources cannot exit until c.lock is acquired
    return runSynced(&c.lock, func() error {
			c.replaceResourceCache(api.GroupKind, items, ns)
			return nil
		})
	})
})
```

during cluster resyncing method sync is executed that also needs mutex and semaphore in reverse order:

https://github.com/argoproj/gitops-engine/blob/ed70eac8b7bd6b2f276502398fdbccccab5d189a/pkg/cache/cluster.go#L705

```golang
// mutex is acquired before calling this function
func (c *clusterCache) sync() error {
	...
	err = kube.RunAllAsync(len(apis), func(i int) error {
		...

		return c.processApi(client, api, func(resClient dynamic.ResourceInterface, ns string) error {
			// listResources needs to acquire a semaphore which is already acquired by the watchEvents which needs mutex
			resourceVersion, err := c.listResources(ctx, resClient, func(listPager *pager.ListPager) error {
				...
			})
			...
			return nil
		})
	})
	...
}
```

The PR modifies `watchEvents` method so it releases semaphore before getting mutex lock.