### PR TITLE
fix: do not replace namespaces

### DIFF
--- a/pkg/sync/sync_context_test.go
+++ b/pkg/sync/sync_context_test.go
@@ -784,6 +784,7 @@ func TestSync_ServerSideApply(t *testing.T) {
 		{"NoAnnotation", NewPod(), NewPod(), "apply", false, "managerA"},
 		{"ServerSideApplyAnnotationIsSet", withServerSideApplyAnnotation(NewPod()), NewPod(), "apply", true, "managerB"},
 		{"ServerSideApplyAndReplaceAnnotationsAreSet", withReplaceAndServerSideApplyAnnotations(NewPod()), NewPod(), "replace", false, ""},
+		{"ServerSideApplyAndReplaceAnnotationsAreSetNamespace", withReplaceAndServerSideApplyAnnotations(NewNamespace()), NewNamespace(), "update", false, ""},
 		{"LiveObjectMissing", withReplaceAnnotation(NewPod()), nil, "create", false, ""},
 	}
 


### PR DESCRIPTION
When doing `kubectl replace`, namespaces should not be affected. Fixes argoproj/argo-cd#12810 and argoproj/argo-cd#12539.