### PR TITLE
feat: auto respect rbac for discovery/sync

### DIFF
--- a/pkg/cache/cluster.go
+++ b/pkg/cache/cluster.go
@@ -775,9 +775,10 @@ func (c *clusterCache) checkPermission(ctx context.Context, reviewInterface auth
 			}
 			if resp != nil && resp.Status.Allowed {
 				return true, nil
+			} else {
+				// unsupported, remove from watch list
+				return false, nil
 			}
-			// unsupported, remove from watch list
-			return false, nil
 		}
 	}
 	// checkPermission follows the same logic of determining namespace/cluster resource as the processApi function

--- a/pkg/cache/settings.go
+++ b/pkg/cache/settings.go
@@ -158,3 +158,10 @@ func SetRetryOptions(maxRetries int32, useBackoff bool, retryFunc ListRetryFunc)
 		cache.listRetryFunc = retryFunc
 	}
 }
+
+// SetRespectRBAC allows to set whether to respect the controller rbac in list/watches
+func SetRespectRBAC(respectRBA bool) UpdateSettingsFunc {
+	return func(cache *clusterCache) {
+		cache.respectRBAC = respectRBA
+	}
+}

--- a/pkg/cache/settings.go
+++ b/pkg/cache/settings.go
@@ -160,8 +160,13 @@ func SetRetryOptions(maxRetries int32, useBackoff bool, retryFunc ListRetryFunc)
 }
 
 // SetRespectRBAC allows to set whether to respect the controller rbac in list/watches
-func SetRespectRBAC(respectRBA bool) UpdateSettingsFunc {
+func SetRespectRBAC(respectRBAC int) UpdateSettingsFunc {
 	return func(cache *clusterCache) {
-		cache.respectRBAC = respectRBA
+		// if invalid value is provided disable respect rbac
+		if respectRBAC < RespectRbacDisabled || respectRBAC > RespectRbacStrict {
+			cache.respectRBAC = RespectRbacDisabled
+		} else {
+			cache.respectRBAC = respectRBAC
+		}
 	}
 }


### PR DESCRIPTION
This PR implements this [proposal](https://github.com/argoproj/argo-cd/blob/master/docs/proposals/respect-rbac-for-resource-exclusions.md). PR enables gitops engine to automatically stop watching for resources that it does not have permission to access without having to manually set resource exclusions.