### PR TITLE
fix: formatting of log messages

### DIFF
--- a/pkg/cache/cluster.go
+++ b/pkg/cache/cluster.go
@@ -709,7 +709,7 @@ func (c *clusterCache) watchEvents(ctx context.Context, api kube.APIResourceInfo
 							if !ok {
 								return err
 							}
-							c.log.Info("warning loading openapi schema: %s", e)
+							c.log.Info(fmt.Sprintf("warning loading openapi schema: %s", e.Error()))
 						}
 						if gvkParser != nil {
 							c.gvkParser = gvkParser
@@ -823,7 +823,7 @@ func (c *clusterCache) sync() error {
 		if !ok {
 			return err
 		}
-		c.log.Info("warning loading openapi schema: %s", e.Error())
+		c.log.Info(fmt.Sprintf("warning loading openapi schema: %s", e.Error()))
 	}
 
 	if gvkParser != nil {


### PR DESCRIPTION
Argocd application controller 2.8 outputs logs like this:
```
time="2023-09-19T10:49:45Z" level=info msg="warning loading openapi schema: %s" server="https://172.18.1.1:6443"
```
