### PR TITLE
chore: log cluster sync error

### DIFF
--- a/pkg/cache/cluster.go
+++ b/pkg/cache/cluster.go
@@ -898,6 +898,7 @@ func (c *clusterCache) sync() error {
 	})
 
 	if err != nil {
+		c.log.Error(err, "Failed to sync cluster")
 		return fmt.Errorf("failed to sync cluster %s: %v", c.config.Host, err)
 	}
 


### PR DESCRIPTION
Right now we only pass this up to the caller to log. That has two downsides:
1) The caller may not log it (there's at least one such case in Argo CD)
2) The caller may log it _too often_, producing duplicate log lines and making it difficult to determine exactly how many clusters are "sick" - for example, Argo CD logs this error for every single Application deployed to the sick cluster