### PR TITLE
fix: remove lock acquisition in ClusterCache.GetAPIResources()

### DIFF
--- a/pkg/cache/cluster.go
+++ b/pkg/cache/cluster.go
@@ -300,10 +300,11 @@ func (c *clusterCache) GetServerVersion() string {
 }
 
 // GetAPIResources returns information about observed API resources
+// This method is called frequently during reconciliation to pass API resource info to `helm template`
+// NOTE: we do not provide any consistency guarantees about the returned list. The list might be
+// updated in place (anytime new CRDs are introduced or removed). If necessary, a separate method
+// would need to be introduced to return a copy of the list so it can be iterated consistently.
 func (c *clusterCache) GetAPIResources() []kube.APIResourceInfo {
-	c.lock.RLock()
-	defer c.lock.RUnlock()
-
 	return c.apiResources
 }
 


### PR DESCRIPTION
Partially addresses https://github.com/argoproj/argo-cd/issues/15850.

The lock we were acquiring in GetAPIResources() was unnecessary and caused Argo CD app reconciliation to spend extra time waiting to get API resource information. 