### PR TITLE
Update condition to select right pvc as child for statefulset

### DIFF
--- a/pkg/cache/references.go
+++ b/pkg/cache/references.go
@@ -3,8 +3,7 @@ package cache
 import (
 	"encoding/json"
 	"fmt"
-	"strings"
-
+    "regexp"
 	v1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -75,7 +74,7 @@ func isStatefulSetChild(un *unstructured.Unstructured) (func(kube.ResourceKey) b
 	return func(key kube.ResourceKey) bool {
 		if key.Kind == kube.PersistentVolumeClaimKind && key.GroupKind().Group == "" {
 			for _, templ := range templates {
-				if strings.HasPrefix(key.Name, fmt.Sprintf("%s-%s-", templ.Name, un.GetName())) {
+				if match, _ := regexp.MatchString(fmt.Sprintf(`%s-%s-\d+$`, templ.Name, un.GetName()), key.Name); match  {
 					return true
 				}
 			}

--- a/pkg/cache/references.go
+++ b/pkg/cache/references.go
@@ -3,7 +3,7 @@ package cache
 import (
 	"encoding/json"
 	"fmt"
-    "regexp"
+        "regexp"
 	v1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"

--- a/pkg/cache/references_test.go
+++ b/pkg/cache/references_test.go
@@ -1,0 +1,105 @@
+package cache
+
+import (
+	"github.com/argoproj/gitops-engine/pkg/utils/kube"
+	"github.com/stretchr/testify/assert"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"testing"
+)
+
+func Test_isStatefulSetChild(t *testing.T) {
+	type args struct {
+		un *unstructured.Unstructured
+	}
+
+	statefulSet := &appsv1.StatefulSet{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "apps/v1",
+			Kind:       "StatefulSet",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "sw-broker",
+		},
+		Spec: appsv1.StatefulSetSpec{
+			VolumeClaimTemplates: []corev1.PersistentVolumeClaim{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "emqx-data",
+					},
+				},
+			},
+		},
+	}
+
+	// Create a new unstructured object from the JSON string
+	un, err := kube.ToUnstructured(statefulSet)
+	if err != nil {
+		t.Errorf("Failed to convert StatefulSet to unstructured: %v", err)
+	}
+
+	tests := []struct {
+		name      string
+		args      args
+		wantErr   bool
+		checkFunc func(func(kube.ResourceKey) bool) bool
+	}{
+		{
+			name:    "Valid PVC for sw-broker",
+			args:    args{un: un},
+			wantErr: false,
+			checkFunc: func(fn func(kube.ResourceKey) bool) bool {
+				// Check a valid PVC name for "sw-broker"
+				return fn(kube.ResourceKey{Kind: "PersistentVolumeClaim", Name: "emqx-data-sw-broker-0"})
+			},
+		},
+		{
+			name:    "Invalid PVC for sw-broker",
+			args:    args{un: un},
+			wantErr: false,
+			checkFunc: func(fn func(kube.ResourceKey) bool) bool {
+				// Check an invalid PVC name that should belong to "sw-broker-internal"
+				return !fn(kube.ResourceKey{Kind: "PersistentVolumeClaim", Name: "emqx-data-sw-broker-internal-0"})
+			},
+		},
+		{
+			name: "Mismatch PVC for sw-broker",
+			args: args{un: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "apps/v1",
+					"kind":       "StatefulSet",
+					"metadata": map[string]interface{}{
+						"name": "sw-broker",
+					},
+					"spec": map[string]interface{}{
+						"volumeClaimTemplates": []interface{}{
+							map[string]interface{}{
+								"metadata": map[string]interface{}{
+									"name": "volume-2",
+								},
+							},
+						},
+					},
+				},
+			}},
+			wantErr: false,
+			checkFunc: func(fn func(kube.ResourceKey) bool) bool {
+				// Check an invalid PVC name for "api-test"
+				return !fn(kube.ResourceKey{Kind: "PersistentVolumeClaim", Name: "volume-2"})
+			},
+		},
+	}
+
+	// Execute test cases
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := isStatefulSetChild(tt.args.un)
+			assert.Equal(t, tt.wantErr, err != nil, "isStatefulSetChild() error = %v, wantErr %v", err, tt.wantErr)
+			if err == nil {
+				assert.True(t, tt.checkFunc(got), "Check function failed for %v", tt.name)
+			}
+		})
+	}
+}


### PR DESCRIPTION
We have 2 pvc in namespace, one with name `emqx-data-sw-broker-0` for statefulset `sw-broker` and other one is `emqx-data-sw-broker-internal-0` for statefulset `sw-broker-internal` and both have same template name `emqx-data`. since `emqx-data-sw-broker-internal-0` contains prefix `emqx-data-sw-broker-`, it consider it as part of sw-broker statefulset which is not right. fixing condition to check if it contains number at the end of prefix
