### PR TITLE
Object-level prune propagation policy, propagation policy for kubectl replace

### DIFF
--- a/pkg/sync/common/types.go
+++ b/pkg/sync/common/types.go
@@ -32,7 +32,10 @@ const (
 	// Sync option that disables resource deletion
 	SyncOptionDisableDeletion = "Delete=false"
 	// Sync option that sync only out of sync resources
-	SyncOptionApplyOutOfSyncOnly = "ApplyOutOfSyncOnly=true"
+	SyncOptionApplyOutOfSyncOnly               = "ApplyOutOfSyncOnly=true"
+	SyncOptionPrunePropagationPolicyForeground = "PrunePropagationPolicy=foreground"
+	SyncOptionPrunePropagationPolicyBackground = "PrunePropagationPolicy=background"
+	SyncOptionPrunePropagationPolicyOrphan     = "PrunePropagationPolicy=orphan"
 )
 
 type PermissionValidator func(un *unstructured.Unstructured, res *metav1.APIResource) error

--- a/pkg/utils/kube/kubetest/mock_resource_operations.go
+++ b/pkg/utils/kube/kubetest/mock_resource_operations.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 
 	"github.com/argoproj/gitops-engine/pkg/utils/kube"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/watch"
@@ -104,7 +105,7 @@ func (r *MockResourceOps) ApplyResource(ctx context.Context, obj *unstructured.U
 	return command.Output, command.Err
 }
 
-func (r *MockResourceOps) ReplaceResource(ctx context.Context, obj *unstructured.Unstructured, dryRunStrategy cmdutil.DryRunStrategy, force bool) (string, error) {
+func (r *MockResourceOps) ReplaceResource(ctx context.Context, obj *unstructured.Unstructured, dryRunStrategy cmdutil.DryRunStrategy, force bool, cascadingStrategy metav1.DeletionPropagation) (string, error) {
 	command, ok := r.Commands[obj.GetName()]
 	r.SetLastResourceCommand(kube.GetResourceKey(obj), "replace")
 


### PR DESCRIPTION
- add object-level prune propagation configuration
- add cascading option for kubectl replace

Fixes https://github.com/argoproj/argo-cd/issues/8501