### PR TITLE
fix(server): Application sync fails when `CreateNamespace` and `ServerSideApply` flags are set in the sync options

### DIFF
--- a/pkg/sync/sync_context.go
+++ b/pkg/sync/sync_context.go
@@ -921,13 +921,13 @@ func (sc *syncContext) applyObject(t *syncTask, dryRun, force, validate bool) (c
 	var err error
 	var message string
 	shouldReplace := sc.replace || resourceutil.HasAnnotationOption(t.targetObj, common.AnnotationSyncOptions, common.SyncOptionReplace)
-	applyFn := func(dryRunStrategy cmdutil.DryRunStrategy, serverSideApplyFlag bool) (string, error) {
-		sc.log.Info(fmt.Sprintf("calling applyFn using dry run strategy: %v and server side apply %v", dryRunStrategy, serverSideApplyFlag))
+	applyFn := func(dryRunOption cmdutil.DryRunStrategy, serverSideApplyFlag bool) (string, error) {
+		sc.log.Info(fmt.Sprintf("calling applyFn using dry run strategy: %v and server side apply %v", dryRunOption, serverSideApplyFlag))
 		if !shouldReplace {
-			return sc.resourceOps.ApplyResource(context.TODO(), t.targetObj, dryRunStrategy, force, validate, serverSideApplyFlag, sc.serverSideApplyManager, false)
+			return sc.resourceOps.ApplyResource(context.TODO(), t.targetObj, dryRunOption, force, validate, serverSideApplyFlag, sc.serverSideApplyManager, false)
 		}
 		if t.liveObj == nil {
-			return sc.resourceOps.CreateResource(context.TODO(), t.targetObj, dryRunStrategy, validate)
+			return sc.resourceOps.CreateResource(context.TODO(), t.targetObj, dryRunOption, validate)
 		}
 		// Avoid using `kubectl replace` for CRDs since 'replace' might recreate resource and so delete all CRD instances.
 		// The same thing applies for namespaces, which would delete the namespace as well as everything within it,
@@ -935,13 +935,13 @@ func (sc *syncContext) applyObject(t *syncTask, dryRun, force, validate bool) (c
 		if kube.IsCRD(t.targetObj) || t.targetObj.GetKind() == kubeutil.NamespaceKind {
 			update := t.targetObj.DeepCopy()
 			update.SetResourceVersion(t.liveObj.GetResourceVersion())
-			_, err := sc.resourceOps.UpdateResource(context.TODO(), update, dryRunStrategy)
+			_, err := sc.resourceOps.UpdateResource(context.TODO(), update, dryRunOption)
 			if err != nil {
 				return fmt.Sprintf("error when updating: %v", err.Error()), err
 			}
 			return fmt.Sprintf("%s/%s updated", t.targetObj.GetKind(), t.targetObj.GetName()), nil
 		}
-		return sc.resourceOps.ReplaceResource(context.TODO(), t.targetObj, dryRunStrategy, force)
+		return sc.resourceOps.ReplaceResource(context.TODO(), t.targetObj, dryRunOption, force)
 	}
 	message, err = applyFn(dryRunStrategy, serverSideApply)
 	// DryRunServer fails with "Kind does not support fieldValidation" error for kubernetes server < 1.25

--- a/pkg/sync/sync_context.go
+++ b/pkg/sync/sync_context.go
@@ -935,7 +935,7 @@ func (sc *syncContext) applyObject(t *syncTask, dryRun, force, validate bool) (c
 		if kube.IsCRD(t.targetObj) || t.targetObj.GetKind() == kubeutil.NamespaceKind {
 			update := t.targetObj.DeepCopy()
 			update.SetResourceVersion(t.liveObj.GetResourceVersion())
-			_, err := sc.resourceOps.UpdateResource(context.TODO(), update, dryRunStrategy)
+			_, err = sc.resourceOps.UpdateResource(context.TODO(), update, dryRunStrategy)
 			if err != nil {
 				return fmt.Sprintf("error when updating: %v", err.Error()), err
 			}
@@ -943,7 +943,9 @@ func (sc *syncContext) applyObject(t *syncTask, dryRun, force, validate bool) (c
 		}
 		return sc.resourceOps.ReplaceResource(context.TODO(), t.targetObj, dryRunStrategy, force)
 	}
+
 	message, err = applyFn(dryRunStrategy, serverSideApply)
+
 	// DryRunServer fails with "Kind does not support fieldValidation" error for kubernetes server < 1.25
 	// it fails inside apply.go , o.DryRunVerifier.HasSupport(info.Mapping.GroupVersionKind) line
 	// so we retry with DryRunClient that works for all cases, but cause issues with hooks
@@ -958,7 +960,7 @@ func (sc *syncContext) applyObject(t *syncTask, dryRun, force, validate bool) (c
 	}
 	if kube.IsCRD(t.targetObj) && !dryRun {
 		crdName := t.targetObj.GetName()
-		if err := sc.ensureCRDReady(crdName); err != nil {
+		if err = sc.ensureCRDReady(crdName); err != nil {
 			sc.log.Error(err, fmt.Sprintf("failed to ensure that CRD %s is ready", crdName))
 		}
 	}


### PR DESCRIPTION
#### Root Cause: 
When server side apply is set to true, dry run is run in server mode, if the dry run fails in server mode, then it is re-run in client mode. But the server side apply is still set. This is not a supported configuration in `kubectl` when `--dry-run` is set to client, `--server-side` flag is not supported.

```
# kubectl apply -k kustomize-guestbook --dry-run=client --server-side -n guestbook -o json
error: --dry-run=client doesn't work with --server-side (did you mean --dry-run=server instead?)
``` 
#### Solution
When `kubectl apply --dry-run=server --server-side` fails, then re-run the dry run in client mode and with `server-side` flag removed as below
```
# kubectl apply -k kustomize-guestbook --dry-run=client -n guestbook -o json