### PR TITLE
fix(server): Dry run always in client mode just for yaml manifest validation even with server side apply

### DIFF
--- a/pkg/sync/sync_context.go
+++ b/pkg/sync/sync_context.go
@@ -921,39 +921,29 @@ func (sc *syncContext) applyObject(t *syncTask, dryRun, force, validate bool) (c
 	var err error
 	var message string
 	shouldReplace := sc.replace || resourceutil.HasAnnotationOption(t.targetObj, common.AnnotationSyncOptions, common.SyncOptionReplace)
-	applyFn := func(dryRunStrategy cmdutil.DryRunStrategy) (string, error) {
-		if !shouldReplace {
-			return sc.resourceOps.ApplyResource(context.TODO(), t.targetObj, dryRunStrategy, force, validate, serverSideApply, sc.serverSideApplyManager, false)
-		}
-		if t.liveObj == nil {
-			return sc.resourceOps.CreateResource(context.TODO(), t.targetObj, dryRunStrategy, validate)
-		}
-		// Avoid using `kubectl replace` for CRDs since 'replace' might recreate resource and so delete all CRD instances.
-		// The same thing applies for namespaces, which would delete the namespace as well as everything within it,
-		// so we want to avoid using `kubectl replace` in that case as well.
-		if kube.IsCRD(t.targetObj) || t.targetObj.GetKind() == kubeutil.NamespaceKind {
-			update := t.targetObj.DeepCopy()
-			update.SetResourceVersion(t.liveObj.GetResourceVersion())
-			_, err = sc.resourceOps.UpdateResource(context.TODO(), update, dryRunStrategy)
-			if err != nil {
-				return fmt.Sprintf("error when updating: %v", err.Error()), err
+	if shouldReplace {
+		if t.liveObj != nil {
+			// Avoid using `kubectl replace` for CRDs since 'replace' might recreate resource and so delete all CRD instances.
+			// The same thing applies for namespaces, which would delete the namespace as well as everything within it,
+			// so we want to avoid using `kubectl replace` in that case as well.
+			if kube.IsCRD(t.targetObj) || t.targetObj.GetKind() == kubeutil.NamespaceKind {
+				update := t.targetObj.DeepCopy()
+				update.SetResourceVersion(t.liveObj.GetResourceVersion())
+				_, err = sc.resourceOps.UpdateResource(context.TODO(), update, dryRunStrategy)
+				if err == nil {
+					message = fmt.Sprintf("%s/%s updated", t.targetObj.GetKind(), t.targetObj.GetName())
+				} else {
+					message = fmt.Sprintf("error when updating: %v", err.Error())
+				}
+			} else {
+				message, err = sc.resourceOps.ReplaceResource(context.TODO(), t.targetObj, dryRunStrategy, force)
 			}
-			return fmt.Sprintf("%s/%s updated", t.targetObj.GetKind(), t.targetObj.GetName()), nil
-
+		} else {
+			message, err = sc.resourceOps.CreateResource(context.TODO(), t.targetObj, dryRunStrategy, validate)
 		}
-		return sc.resourceOps.ReplaceResource(context.TODO(), t.targetObj, dryRunStrategy, force)
+	} else {
+		message, err = sc.resourceOps.ApplyResource(context.TODO(), t.targetObj, dryRunStrategy, force, validate, serverSideApply, sc.serverSideApplyManager, false)
 	}
-
-	message, err = applyFn(dryRunStrategy)
-
-	// DryRunServer fails with "Kind does not support fieldValidation" error for kubernetes server < 1.25
-	// it fails inside apply.go , o.DryRunVerifier.HasSupport(info.Mapping.GroupVersionKind) line
-	// so we retry with DryRunClient that works for all cases, but cause issues with hooks
-	// Details: https://github.com/argoproj/argo-cd/issues/16177
-	if dryRunStrategy == cmdutil.DryRunServer && err != nil {
-		message, err = applyFn(cmdutil.DryRunClient)
-	}
-
 	if err != nil {
 		return common.ResultCodeSyncFailed, err.Error()
 	}

--- a/pkg/sync/sync_context.go
+++ b/pkg/sync/sync_context.go
@@ -909,6 +909,8 @@ func (sc *syncContext) applyObject(t *syncTask, dryRun, force, validate bool) (c
 		// irrespective of the dry run mode set in the sync context, always run
 		// in client dry run mode as the goal is to validate only the
 		// yaml correctness of the rendered manifests.
+		// running dry-run in server mode breaks the auto create namespace feature
+		// https://github.com/argoproj/argo-cd/issues/13874
 		dryRunStrategy = cmdutil.DryRunClient
 	}
 
@@ -917,6 +919,8 @@ func (sc *syncContext) applyObject(t *syncTask, dryRun, force, validate bool) (c
 	shouldReplace := sc.replace || resourceutil.HasAnnotationOption(t.targetObj, common.AnnotationSyncOptions, common.SyncOptionReplace)
 	// if it is a dry run, disable server side apply, as the goal is to validate only the
 	// yaml correctness of the rendered manifests.
+	// running dry-run in server mode breaks the auto create namespace feature
+	// https://github.com/argoproj/argo-cd/issues/13874
 	serverSideApply := !dryRun && (sc.serverSideApply || resourceutil.HasAnnotationOption(t.targetObj, common.AnnotationSyncOptions, common.SyncOptionServerSideApply))
 	if shouldReplace {
 		if t.liveObj != nil {

--- a/pkg/sync/sync_context.go
+++ b/pkg/sync/sync_context.go
@@ -903,24 +903,16 @@ func (sc *syncContext) ensureCRDReady(name string) error {
 	})
 }
 
-func getDryRunStrategy(serverSideApply, dryRun bool) cmdutil.DryRunStrategy {
-	if !dryRun {
-		return cmdutil.DryRunNone
-	}
-	if serverSideApply {
-		return cmdutil.DryRunServer
-	}
-	return cmdutil.DryRunClient
-}
-
 func (sc *syncContext) applyObject(t *syncTask, dryRun, force, validate bool) (common.ResultCode, string) {
-	serverSideApply := sc.serverSideApply || resourceutil.HasAnnotationOption(t.targetObj, common.AnnotationSyncOptions, common.SyncOptionServerSideApply)
-
-	dryRunStrategy := getDryRunStrategy(serverSideApply, dryRun)
+	dryRunStrategy := cmdutil.DryRunNone
+	if dryRun {
+		dryRunStrategy = cmdutil.DryRunClient
+	}
 
 	var err error
 	var message string
 	shouldReplace := sc.replace || resourceutil.HasAnnotationOption(t.targetObj, common.AnnotationSyncOptions, common.SyncOptionReplace)
+	serverSideApply := sc.serverSideApply || resourceutil.HasAnnotationOption(t.targetObj, common.AnnotationSyncOptions, common.SyncOptionServerSideApply)
 	if shouldReplace {
 		if t.liveObj != nil {
 			// Avoid using `kubectl replace` for CRDs since 'replace' might recreate resource and so delete all CRD instances.

--- a/pkg/sync/sync_context_test.go
+++ b/pkg/sync/sync_context_test.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"k8s.io/kubectl/pkg/cmd/util"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
@@ -538,25 +537,6 @@ func (s *APIServerMock) newHttpServer(t *testing.T, apiFailuresCount int) *httpt
 		w.Write(output) // nolint:errcheck
 	}))
 	return server
-}
-
-func TestGetDryRunStrategy(t *testing.T) {
-	t.Run("no dry run", func(t *testing.T) {
-		strategy := getDryRunStrategy(false, false)
-		assert.Equal(t, util.DryRunNone, strategy)
-	})
-	t.Run("no dry run with server side apply", func(t *testing.T) {
-		strategy := getDryRunStrategy(true, false)
-		assert.Equal(t, util.DryRunNone, strategy)
-	})
-	t.Run("dry run with server side apply", func(t *testing.T) {
-		strategy := getDryRunStrategy(true, true)
-		assert.Equal(t, util.DryRunServer, strategy)
-	})
-	t.Run("dry run with client side apply", func(t *testing.T) {
-		strategy := getDryRunStrategy(false, true)
-		assert.Equal(t, util.DryRunClient, strategy)
-	})
 }
 
 func TestServerResourcesRetry(t *testing.T) {

--- a/pkg/utils/kube/resource_ops.go
+++ b/pkg/utils/kube/resource_ops.go
@@ -233,8 +233,7 @@ func (k *kubectlResourceOperations) ApplyResource(ctx context.Context, obj *unst
 		"dry-run", dryRunStrategy,
 		"manager", manager,
 		"serverSideApply", serverSideApply,
-		"serverSideDiff", serverSideDiff
-		).Info(fmt.Sprintf("Applying resource %s/%s in cluster: %s, namespace: %s", obj.GetKind(), obj.GetName(), k.config.Host, obj.GetNamespace()))
+		"serverSideDiff", serverSideDiff).Info(fmt.Sprintf("Applying resource %s/%s in cluster: %s, namespace: %s", obj.GetKind(), obj.GetName(), k.config.Host, obj.GetNamespace()))
 	return k.runResourceCommand(ctx, obj, dryRunStrategy, func(f cmdutil.Factory, ioStreams genericclioptions.IOStreams, fileName string) error {
 		cleanup, err := k.processKubectlRun("apply")
 		if err != nil {

--- a/pkg/utils/kube/resource_ops.go
+++ b/pkg/utils/kube/resource_ops.go
@@ -229,7 +229,12 @@ func (k *kubectlResourceOperations) ApplyResource(ctx context.Context, obj *unst
 	span.SetBaggageItem("kind", obj.GetKind())
 	span.SetBaggageItem("name", obj.GetName())
 	defer span.Finish()
-	k.log.Info(fmt.Sprintf("Applying resource %s/%s in cluster: %s, namespace: %s", obj.GetKind(), obj.GetName(), k.config.Host, obj.GetNamespace()))
+	k.log.WithValues(
+		"dry-run", dryRunStrategy,
+		"manager", manager,
+		"serverSideApply", serverSideApply,
+		"serverSideDiff", serverSideDiff
+		).Info(fmt.Sprintf("Applying resource %s/%s in cluster: %s, namespace: %s", obj.GetKind(), obj.GetName(), k.config.Host, obj.GetNamespace()))
 	return k.runResourceCommand(ctx, obj, dryRunStrategy, func(f cmdutil.Factory, ioStreams genericclioptions.IOStreams, fileName string) error {
 		cleanup, err := k.processKubectlRun("apply")
 		if err != nil {

--- a/pkg/utils/kube/resource_ops.go
+++ b/pkg/utils/kube/resource_ops.go
@@ -230,7 +230,7 @@ func (k *kubectlResourceOperations) ApplyResource(ctx context.Context, obj *unst
 	span.SetBaggageItem("name", obj.GetName())
 	defer span.Finish()
 	k.log.WithValues(
-		"dry-run", dryRunStrategy,
+		"dry-run", [...]string{"none", "client", "server"}[dryRunStrategy],
 		"manager", manager,
 		"serverSideApply", serverSideApply,
 		"serverSideDiff", serverSideDiff).Info(fmt.Sprintf("Applying resource %s/%s in cluster: %s, namespace: %s", obj.GetKind(), obj.GetName(), k.config.Host, obj.GetNamespace()))


### PR DESCRIPTION
#### Root Cause: 
When server side apply is set to true, dry run is run in server mode. Dry run in server mode will fail if the target namespace is missing. So in cases where the sync option `CreateNamespace` is set to true, the dry run fails in server mode, and then attempts to re-run in client mode as a fallback mechanism. But the server side apply is still set. This is not a supported configuration in `kubectl` when `--dry-run` is set to client, `--server-side` flag is not supported causing that to fail as well with the below error message
```
# kubectl apply -k kustomize-guestbook --dry-run=client --server-side -n guestbook -o json
error: --dry-run=client doesn't work with --server-side (did you mean --dry-run=server instead?)
``` 
Due to this behaviour, when both `CreateNamespace=true` and `ServerSideApply=true` sync options are used, then the app sync fails while trying to validate the rendered yaml manifests.

#### Solution
If it is a dry run, always run the dry run in client mode `--dry-run=client` even if the server side apply option is set `--server-side`. Dry runs are used for validating if the rendered manifests satisfy the yaml correctness. For the actual sync, honour the `--server-side` apply flag.

Fixes 
https://github.com/argoproj/argo-cd/issues/16829 
https://github.com/argoproj/argo-cd/issues/13874
https://github.com/argoproj/argo-cd/issues/16840