### PR TITLE
fix: temporary files written to '/dev/shm' not cleaned up (#568)

### DIFF
--- a/pkg/utils/io/io.go
+++ b/pkg/utils/io/io.go
@@ -5,6 +5,7 @@ import (
 )
 
 var (
+	// TempDir is set to '/dev/shm' if exists, otherwise is "", which defaults to os.TempDir() when passed to os.CreateTemp()
 	TempDir string
 )
 

--- a/pkg/utils/kube/ctl.go
+++ b/pkg/utils/kube/ctl.go
@@ -291,6 +291,7 @@ func (k *KubectlCmd) ManageResources(config *rest.Config, openAPISchema openapi.
 	_ = f.Close()
 	err = WriteKubeConfig(config, "", f.Name())
 	if err != nil {
+		utils.DeleteFile(f.Name())
 		return nil, nil, fmt.Errorf("failed to write kubeconfig: %v", err)
 	}
 	fact := kubeCmdFactory(f.Name(), "", config)

--- a/pkg/utils/kube/resource_ops.go
+++ b/pkg/utils/kube/resource_ops.go
@@ -64,13 +64,13 @@ func (k *kubectlResourceOperations) runResourceCommand(ctx context.Context, obj 
 	if err != nil {
 		return "", fmt.Errorf("Failed to generate temp file for manifest: %v", err)
 	}
+	defer io.DeleteFile(manifestFile.Name())
 	if _, err = manifestFile.Write(manifestBytes); err != nil {
 		return "", fmt.Errorf("Failed to write manifest: %v", err)
 	}
 	if err = manifestFile.Close(); err != nil {
 		return "", fmt.Errorf("Failed to close manifest: %v", err)
 	}
-	defer io.DeleteFile(manifestFile.Name())
 
 	// log manifest
 	if k.log.V(1).Enabled() {


### PR DESCRIPTION
Fixes #568 

See [parent issue](https://github.com/argoproj/gitops-engine/issues/568) for details of the problem

This PR:
- `ctl.go`: Adds a call to `DeleteFile` to handle the (rare) case where `WriteKubeConfig` fails.
- `resource_ops.go`: Moves `defer io.DeleteFile(...)` call to handle the (rare) case where Write or Close fail.

Admittedly, these are likely to be rare: it's unlikely that writing to a file would fail, when that file was already successfully created earlier in the function.