### PR TITLE
fix cluster resources

### DIFF
--- a/pkg/cache/cluster.go
+++ b/pkg/cache/cluster.go
@@ -979,7 +979,7 @@ func (c *clusterCache) IterateHierarchy(key kube.ResourceKey, action func(resour
 		if key.Namespace == "" {
 			childRefs := c.childrenByParent[key]
 			for _, childRef := range childRefs {
-				if _, ok := nsNodes[childRef]; !ok {
+				if c.resources[childRef] != nil {
 					nsNodes[childRef] = c.resources[childRef]
 				}
 			}
@@ -1152,9 +1152,7 @@ func (c *clusterCache) onNodeUpdated(oldRes *Resource, newRes *Resource) {
 }
 
 func (c *clusterCache) onNodeRemoved(key kube.ResourceKey) {
-	if _, ok := c.childrenByParent[key]; ok {
-		delete(c.childrenByParent, key)
-	}
+	delete(c.childrenByParent, key)
 	existing, ok := c.resources[key]
 	if ok {
 		delete(c.resources, key)

--- a/pkg/cache/cluster.go
+++ b/pkg/cache/cluster.go
@@ -976,6 +976,10 @@ func (c *clusterCache) IterateHierarchy(key kube.ResourceKey, action func(resour
 		if !action(res, nsNodes) {
 			return
 		}
+		if key.Namespace == "" {
+			// if the resource is cluster scoped, include objects from all namespaces
+			nsNodes = c.resources
+		}
 		childrenByUID := make(map[types.UID][]*Resource)
 		for _, child := range nsNodes {
 			if res.isParentOf(child) {

--- a/pkg/cache/cluster.go
+++ b/pkg/cache/cluster.go
@@ -990,6 +990,7 @@ func (c *clusterCache) IterateHierarchy(key kube.ResourceKey, action func(resour
 					childResources[childRef] = c.resources[childRef]
 				}
 			}
+			// Merge the maps into a different copy to avoid updating the original nsIndex map
 			nsNodes = mergeResourceMaps(nsNodes, childResources)
 		}
 		if !action(res, nsNodes) {
@@ -1198,6 +1199,8 @@ func (c *clusterCache) onNodeRemoved(key kube.ResourceKey) {
 	}
 }
 
+// mergeResourceMaps merges the given maps into a different copy in order to avoid updates
+// to the original maps
 func mergeResourceMaps(a, b map[kube.ResourceKey]*Resource) map[kube.ResourceKey]*Resource {
 	mergedMap := map[kube.ResourceKey]*Resource{}
 	for k, v := range a {
@@ -1254,6 +1257,7 @@ func (c *clusterCache) removeFromChildrenByParentMap(key kube.ResourceKey) {
 		for i, childRef := range childRefs {
 			childRefKey := kube.NewResourceKey(childRef.Group, childRef.Kind, childRef.Namespace, childRef.Name)
 			if childRefKey == key {
+				// remove the childRef that matches the deleted resource
 				childRefs[i] = childRefs[len(childRefs)-1]
 				c.childrenByParent[k] = childRefs[:len(childRefs)-1]
 			}

--- a/pkg/cache/cluster.go
+++ b/pkg/cache/cluster.go
@@ -976,6 +976,20 @@ func (c *clusterCache) FindResources(namespace string, predicates ...func(r *Res
 	return result
 }
 
+func (c *clusterCache) addChildResourcesRecursivly(nsNodes map[kube.ResourceKey]*Resource, key kube.ResourceKey) map[kube.ResourceKey]*Resource {
+	nsNodeReturned := nsNodes
+	childRefs := c.childrenByParent[key]
+	childResources := map[kube.ResourceKey]*Resource{}
+	for _, childRef := range childRefs {
+		if c.resources[childRef] != nil {
+			childResources[childRef] = c.resources[childRef]
+			nsNodeReturned = c.addChildResourcesRecursivly(nsNodeReturned, childRef)
+		}
+	}
+	// Merge the maps into a different copy to avoid updating the original nsIndex map
+	return mergeResourceMaps(nsNodeReturned, childResources)
+}
+
 // IterateHierarchy iterates resource tree starting from the specified top level resource and executes callback for each resource in the tree
 func (c *clusterCache) IterateHierarchy(key kube.ResourceKey, action func(resource *Resource, namespaceResources map[kube.ResourceKey]*Resource) bool) {
 	c.lock.RLock()
@@ -983,15 +997,7 @@ func (c *clusterCache) IterateHierarchy(key kube.ResourceKey, action func(resour
 	if res, ok := c.resources[key]; ok {
 		nsNodes := c.nsIndex[key.Namespace]
 		if key.Namespace == "" && c.showClusterResourceChildren {
-			childRefs := c.childrenByParent[key]
-			childResources := map[kube.ResourceKey]*Resource{}
-			for _, childRef := range childRefs {
-				if c.resources[childRef] != nil {
-					childResources[childRef] = c.resources[childRef]
-				}
-			}
-			// Merge the maps into a different copy to avoid updating the original nsIndex map
-			nsNodes = mergeResourceMaps(nsNodes, childResources)
+			nsNodes = c.addChildResourcesRecursivly(nsNodes, key)
 		}
 		if !action(res, nsNodes) {
 			return

--- a/pkg/cache/cluster.go
+++ b/pkg/cache/cluster.go
@@ -153,6 +153,7 @@ func NewClusterCache(config *rest.Config, opts ...UpdateSettingsFunc) *clusterCa
 		listSemaphore:      semaphore.NewWeighted(defaultListSemaphoreWeight),
 		resources:          make(map[kube.ResourceKey]*Resource),
 		nsIndex:            make(map[string]map[kube.ResourceKey]*Resource),
+		childrenByParent:   make(map[kube.ResourceKey][]kube.ResourceKey),
 		config:             config,
 		kubectl: &kube.KubectlCmd{
 			Log:    log,
@@ -206,6 +207,8 @@ type clusterCache struct {
 	lock      sync.RWMutex
 	resources map[kube.ResourceKey]*Resource
 	nsIndex   map[string]map[kube.ResourceKey]*Resource
+	// childrenByParent maps a parent ref to the list of child refs
+	childrenByParent map[kube.ResourceKey][]kube.ResourceKey
 
 	kubectl          kube.Kubectl
 	log              logr.Logger
@@ -973,12 +976,16 @@ func (c *clusterCache) IterateHierarchy(key kube.ResourceKey, action func(resour
 	defer c.lock.RUnlock()
 	if res, ok := c.resources[key]; ok {
 		nsNodes := c.nsIndex[key.Namespace]
+		if key.Namespace == "" {
+			childRefs := c.childrenByParent[key]
+			for _, childRef := range childRefs {
+				if _, ok := nsNodes[childRef]; !ok {
+					nsNodes[childRef] = c.resources[childRef]
+				}
+			}
+		}
 		if !action(res, nsNodes) {
 			return
-		}
-		if key.Namespace == "" {
-			// if the resource is cluster scoped, include objects from all namespaces
-			nsNodes = c.resources
 		}
 		childrenByUID := make(map[types.UID][]*Resource)
 		for _, child := range nsNodes {
@@ -1137,6 +1144,7 @@ func (c *clusterCache) processEvent(event watch.EventType, un *unstructured.Unst
 }
 
 func (c *clusterCache) onNodeUpdated(oldRes *Resource, newRes *Resource) {
+	c.updateChildrenByParentMap(newRes)
 	c.setNode(newRes)
 	for _, h := range c.getResourceUpdatedHandlers() {
 		h(newRes, oldRes, c.nsIndex[newRes.Ref.Namespace])
@@ -1144,6 +1152,9 @@ func (c *clusterCache) onNodeUpdated(oldRes *Resource, newRes *Resource) {
 }
 
 func (c *clusterCache) onNodeRemoved(key kube.ResourceKey) {
+	if _, ok := c.childrenByParent[key]; ok {
+		delete(c.childrenByParent, key)
+	}
 	existing, ok := c.resources[key]
 	if ok {
 		delete(c.resources, key)
@@ -1165,6 +1176,38 @@ func (c *clusterCache) onNodeRemoved(key kube.ResourceKey) {
 		for _, h := range c.getResourceUpdatedHandlers() {
 			h(nil, existing, ns)
 		}
+	}
+}
+
+func (c *clusterCache) updateChildrenByParentMap(res *Resource) {
+	if res == nil {
+		return
+	}
+	childKey := res.ResourceKey()
+	if _, ok := c.childrenByParent[childKey]; !ok {
+		c.childrenByParent[childKey] = []kube.ResourceKey{}
+	}
+	for _, parent := range res.OwnerRefs {
+		parentGvk := schema.FromAPIVersionAndKind(parent.APIVersion, parent.Kind)
+		var namespace string
+		if isNamespaced, _ := c.IsNamespaced(parentGvk.GroupKind()); isNamespaced {
+			namespace = res.Ref.Namespace
+		}
+		parentKey := kube.NewResourceKey(parentGvk.Group, parentGvk.Kind, namespace, parent.Name)
+		childRefs, ok := c.childrenByParent[parentKey]
+		if !ok {
+			c.childrenByParent[parentKey] = []kube.ResourceKey{}
+		}
+		exists := false
+		for _, cr := range childRefs {
+			if cr == childKey {
+				exists = true
+			}
+		}
+		if !exists {
+			childRefs = append(childRefs, childKey)
+		}
+		c.childrenByParent[parentKey] = childRefs
 	}
 }
 

--- a/pkg/cache/settings.go
+++ b/pkg/cache/settings.go
@@ -170,3 +170,11 @@ func SetRespectRBAC(respectRBAC int) UpdateSettingsFunc {
 		}
 	}
 }
+
+// SetClusterResourcedNamespacedChildren enables/disables the option to show
+// namespaced resources owned by cluster scoped resources.
+func SetClusterResourcedNamespacedChildren(showNamespacedChildren bool) UpdateSettingsFunc {
+	return func(cache *clusterCache) {
+		cache.showClusterResourceChildren = showNamespacedChildren
+	}
+}


### PR DESCRIPTION
- **fix: show namespaced resources owned by cluster scoped resources**
- **Use a map of parentrefs:childrefs to avoid iterating all resources**
- **Fix lint: remove unnecessary guard around call to delete**
- **Add a feature flag for showing cluster scoped namespaced children**
- **Pass feature flag as an option for cluster cache**
- **Include cluster scoped resources while handling resource updates**
- **Add comments to improve readability**
- **fix: grand children**
