### PR TITLE
feat: Add ability to hide certain annotations on secret resources

### DIFF
--- a/pkg/diff/diff.go
+++ b/pkg/diff/diff.go
@@ -1045,8 +1045,12 @@ func HideSecretData(target *unstructured.Unstructured, live *unstructured.Unstru
 		valToReplacement := make(map[string]string)
 		for _, obj := range []*unstructured.Unstructured{target, live, orig} {
 			var annots map[string]interface{}
+			var err error
 			if obj != nil {
-				annots, _, _ = unstructured.NestedMap(obj.Object, "metadata", "annotations")
+				annots, _, err = unstructured.NestedMap(obj.Object, "metadata", "annotations")
+				if err != nil {
+					return nil, nil, fmt.Errorf("unstructured.NestedMap error: %s", err)
+				}
 			}
 			if annots == nil {
 				annots = make(map[string]interface{})
@@ -1063,7 +1067,10 @@ func HideSecretData(target *unstructured.Unstructured, live *unstructured.Unstru
 				valToReplacement[strVal] = replacement
 			}
 			annots[k] = replacement
-			unstructured.SetNestedMap(obj.Object, annots, "metadata", "annotations")
+			err = unstructured.SetNestedMap(obj.Object, annots, "metadata", "annotations")
+			if err != nil {
+				return nil, nil, fmt.Errorf("unstructured.SetNestedField error: %s", err)
+			}
 		}
 	}
 

--- a/pkg/diff/diff.go
+++ b/pkg/diff/diff.go
@@ -969,10 +969,10 @@ func CreateTwoWayMergePatch(orig, new, dataStruct interface{}) ([]byte, bool, er
 	return patch, string(patch) != "{}", nil
 }
 
-// HideSecretData replaces secret data & optional annotations values in specified target, live secrets and in last applied configuration of live secret with stars. Also preserves differences between
-// target, live and last applied config values. E.g. if all three are equal the values would be replaced with same number of stars. If all the are different then number of stars
+// HideSecretData replaces secret data & optional annotations values in specified target, live secrets and in last applied configuration of live secret with plus(+). Also preserves differences between
+// target, live and last applied config values. E.g. if all three are equal the values would be replaced with same number of plus(+). If all are different then number of plus(+)
 // in replacement should be different.
-func HideSecretData(target *unstructured.Unstructured, live *unstructured.Unstructured, hideAnnots map[string]bool) (*unstructured.Unstructured, *unstructured.Unstructured, error) {
+func HideSecretData(target *unstructured.Unstructured, live *unstructured.Unstructured, hideAnnotations map[string]bool) (*unstructured.Unstructured, *unstructured.Unstructured, error) {
 	var orig *unstructured.Unstructured
 	if live != nil {
 		orig, _ = GetLastAppliedConfigAnnotation(live)
@@ -1003,7 +1003,7 @@ func HideSecretData(target *unstructured.Unstructured, live *unstructured.Unstru
 	}
 
 	// hide annotations
-	target, live, orig, err = hide(target, live, orig, hideAnnots, "metadata", "annotations")
+	target, live, orig, err = hide(target, live, orig, hideAnnotations, "metadata", "annotations")
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/diff/diff.go
+++ b/pkg/diff/diff.go
@@ -1075,14 +1075,6 @@ func toString(val interface{}) string {
 	return fmt.Sprintf("%s", val)
 }
 
-func convertSliceToMap(s []string) map[string]bool {
-	m := make(map[string]bool)
-	for _, k := range s {
-		m[k] = true
-	}
-	return m
-}
-
 // remarshal checks resource kind and version and re-marshal using corresponding struct custom marshaller.
 // This ensures that expected resource state is formatter same as actual resource state in kubernetes
 // and allows to find differences between actual and target states more accurately.

--- a/pkg/diff/diff.go
+++ b/pkg/diff/diff.go
@@ -997,19 +997,16 @@ func HideSecretData(target *unstructured.Unstructured, live *unstructured.Unstru
 	}
 
 	var err error
-	// hide data
 	target, live, liveLastAppliedAnnotation, err = hide(target, live, liveLastAppliedAnnotation, keys, "data")
 	if err != nil {
 		return nil, nil, err
 	}
 
-	// hide annotations
 	target, live, liveLastAppliedAnnotation, err = hide(target, live, liveLastAppliedAnnotation, hideAnnotations, "metadata", "annotations")
 	if err != nil {
 		return nil, nil, err
 	}
 
-	// hide last-applied-config annotation
 	if live != nil && liveLastAppliedAnnotation != nil {
 		annotations := live.GetAnnotations()
 		if annotations == nil {
@@ -1041,8 +1038,10 @@ func hide(target, live, liveLastAppliedAnnotation *unstructured.Unstructured, ke
 				// handles an edge case when secret data has nil value
 				// https://github.com/argoproj/argo-cd/issues/5584
 				dataValue, ok, _ := unstructured.NestedFieldCopy(obj.Object, fields...)
-				if !ok || dataValue == nil {
-					continue
+				if ok {
+					if dataValue == nil {
+						continue
+					}
 				}
 				var err error
 				data, _, err = unstructured.NestedMap(obj.Object, fields...)

--- a/pkg/diff/diff_test.go
+++ b/pkg/diff/diff_test.go
@@ -1055,6 +1055,20 @@ func TestHideSecretAnnotations(t *testing.T) {
 			targetNil: true,
 		},
 		{
+			name:       "special case: hide last-applied-config annotation",
+			hideAnnots: map[string]bool{"kubectl.kubernetes.io/last-applied-configuration": true},
+			annots: map[string]interface{}{
+				"token/value": replacement1,
+				"app":         "test",
+				"kubectl.kubernetes.io/last-applied-configuration": `{"apiVersion":"v1","kind":"Secret","metadata":{"annotations":{"app":"test","token/value":"secret","key":"secret-key"},"labels":{"app.kubernetes.io/instance":"test"},"name":"my-secret","namespace":"default"},"type":"Opaque"}`,
+			},
+			expectedAnnots: map[string]interface{}{
+				"app": "test",
+				"kubectl.kubernetes.io/last-applied-configuration": replacement1,
+			},
+			targetNil: true,
+		},
+		{
 			name:           "hide annotations for malformed annotations",
 			hideAnnots:     map[string]bool{"token/value": true, "key": true},
 			annots:         map[string]interface{}{"token/value": 0, "key": "secret", "app": true},

--- a/pkg/utils/kube/resource_ops.go
+++ b/pkg/utils/kube/resource_ops.go
@@ -80,7 +80,7 @@ func (k *kubectlResourceOperations) runResourceCommand(ctx context.Context, obj 
 		if err != nil {
 			return "", err
 		}
-		redacted, _, err := diff.HideSecretData(&obj, nil)
+		redacted, _, err := diff.HideSecretData(&obj, nil, nil)
 		if err != nil {
 			return "", err
 		}


### PR DESCRIPTION
Related to https://github.com/argoproj/argo-cd/issues/15693. 

This PR implements core logic from [argoproj/argo-cd#hide-annotations.md](https://github.com/argoproj/argo-cd/blob/master/docs/proposals/feature-bounties/hide-annotations.md) proposal to hide annotations on secret resources. 

This change will be integrated with Argo CD via https://github.com/argoproj/argo-cd/pull/18216. 

_Integration results:_

https://github.com/user-attachments/assets/f47d7b18-cfbc-4fef-8a63-cd7e670abcc7

