### PR TITLE
fix: replace k8s.io/endpointslice version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -115,6 +115,7 @@ replace (
 	k8s.io/cri-api => k8s.io/cri-api v0.29.2
 	k8s.io/csi-translation-lib => k8s.io/csi-translation-lib v0.29.2
 	k8s.io/dynamic-resource-allocation => k8s.io/dynamic-resource-allocation v0.29.2
+	k8s.io/endpointslice => k8s.io/endpointslice v0.29.0
 	k8s.io/kms => k8s.io/kms v0.29.2
 	k8s.io/kube-aggregator => k8s.io/kube-aggregator v0.29.2
 	k8s.io/kube-controller-manager => k8s.io/kube-controller-manager v0.29.2


### PR DESCRIPTION
Followup for https://github.com/argoproj/gitops-engine/pull/566

PR adds replace for k8s.io/endpointslice to fix `go list -m -json all` command