### PR TITLE
fix: replace k8s.io/endpointslice to v0.29.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -115,7 +115,7 @@ replace (
 	k8s.io/cri-api => k8s.io/cri-api v0.29.2
 	k8s.io/csi-translation-lib => k8s.io/csi-translation-lib v0.29.2
 	k8s.io/dynamic-resource-allocation => k8s.io/dynamic-resource-allocation v0.29.2
-	k8s.io/endpointslice => k8s.io/endpointslice v0.29.0
+	k8s.io/endpointslice => k8s.io/endpointslice v0.29.2
 	k8s.io/kms => k8s.io/kms v0.29.2
 	k8s.io/kube-aggregator => k8s.io/kube-aggregator v0.29.2
 	k8s.io/kube-controller-manager => k8s.io/kube-controller-manager v0.29.2


### PR DESCRIPTION
Sorry - did not notice upgrade to v0.29.2 while working on https://github.com/argoproj/gitops-engine/pull/582 . Fixing the version