### PR TITLE
fix: printing gvkparser error message

### DIFF
--- a/pkg/cache/cluster.go
+++ b/pkg/cache/cluster.go
@@ -711,7 +711,7 @@ func (c *clusterCache) watchEvents(ctx context.Context, api kube.APIResourceInfo
 							if !ok {
 								return err
 							}
-							c.log.Info("warning loading openapi schema: %s", e)
+							c.log.Info("warning: failed to create gvk parser", "error", e.Error())
 						}
 						if gvkParser != nil {
 							c.gvkParser = gvkParser
@@ -825,7 +825,7 @@ func (c *clusterCache) sync() error {
 		if !ok {
 			return err
 		}
-		c.log.Info("warning loading openapi schema: %s", e.Error())
+		c.log.Info("warning: failed to create gvk parser", "error", e.Error())
 	}
 
 	if gvkParser != nil {


### PR DESCRIPTION
The log.Info function doesn't understand format directives, so use key/value to print error message.
Related PR which caused the error to be hidden: #430 

I'm not sure if this should stay at Info level or if it was correct previously at error level because this is a real issue.  The failed gvkParser seems to be the cause of inaccurate diffs: [#18213](https://github.com/argoproj/argo-cd/issues/18213)