### PR TITLE
feat(psp): removing PodSecurityPolicy from kinds #459

### DIFF
--- a/pkg/sync/sync_tasks.go
+++ b/pkg/sync/sync_tasks.go
@@ -29,7 +29,6 @@ func init() {
 		"NetworkPolicy",
 		"ResourceQuota",
 		"LimitRange",
-		"PodSecurityPolicy",
 		"PodDisruptionBudget",
 		"ServiceAccount",
 		"Secret",


### PR DESCRIPTION
closes #459

Based on the testing matrix and the k8s versions in the go.mod, it should be safe to remove the PSP from our kinds list.

https://github.com/argoproj/gitops-engine/blob/a22b34675f57696d55cb9d4abf99f7b07a166654/go.mod#L24
https://argo-cd.readthedocs.io/en/stable/operator-manual/installation/#tested-versions