### PR TITLE
feat: add ExternalSecret to sync wave

### DIFF
--- a/pkg/sync/sync_tasks.go
+++ b/pkg/sync/sync_tasks.go
@@ -60,6 +60,7 @@ func init() {
 		"IngressClass",
 		"Ingress",
 		"APIService",
+		"ExternalSecrets",
 	}
 	for i, kind := range kinds {
 		// make sure none of the above entries are zero, we need that for custom resources

--- a/pkg/sync/sync_tasks_test.go
+++ b/pkg/sync/sync_tasks_test.go
@@ -13,8 +13,8 @@ import (
 )
 
 func Test_syncTasks_kindOrder(t *testing.T) {
-	assert.Equal(t, -35, kindOrder["Namespace"])
-	assert.Equal(t, -1, kindOrder["APIService"])
+	assert.Equal(t, -36, kindOrder["Namespace"])
+	assert.Equal(t, -2, kindOrder["APIService"])
 	assert.Equal(t, 0, kindOrder["MyCRD"])
 }
 


### PR DESCRIPTION
I want to be able to use a `preSync` hook to run some database migrations. This has been working fine, until such a time as updating the container secrets which are using the External Secret Operator and CRD to create a k8s secret which the job created by the `preSync` hook creates mounts. 

As per this Github issue [#9891](https://github.com/argoproj/argo-cd/issues/9891), the recommended approach is to use Argo sync waves. However `ExternalSecret` is not included in one of the predefined `kinds` and therefore cannot be part of a different "wave" meaning that any secrets defined by `ExternalSecrets` cannot be synced before the `preSync` hook as part of the pre Sync wave.

This would allow the `ExternalSecret` to have an annotation such as the following
```
argocd.argoproj.io/sync-wave: "-2"
```

And a `preSync` hook to have a greater weighted sync wave such as 
```
argocd.argoproj.io/sync-wave: "-1"

```
And all other resources which are part of the deployment would default to weight of `0` without the need for an annotation