### PR TITLE
feat: Make cluster cache target the watch cache instead of etcd

### DIFF
--- a/pkg/cache/cluster.go
+++ b/pkg/cache/cluster.go
@@ -553,6 +553,10 @@ func (c *clusterCache) listResources(ctx context.Context, resClient dynamic.Reso
 		}
 
 		listRetry.Steps = int(c.listRetryLimit)
+		// We set the resource version to 0 below to proactively prevent the
+		// list API call from reaching etcd and make the server fetch the data
+		// from the watch cache instead.
+		opts.ResourceVersion = "0"
 		err := retry.OnError(listRetry, c.listRetryFunc, func() error {
 			var ierr error
 			res, ierr = resClient.List(ctx, opts)


### PR DESCRIPTION
Problem statement in https://github.com/argoproj/argo-cd/issues/18838.

This PR addresses the problem partially - starting with delegating the K8s List calls to the watch cache, offloading the etcd.