### PR TITLE
chore: Refactor the method creating sync tasks

### DIFF
--- a/pkg/sync/sync_context.go
+++ b/pkg/sync/sync_context.go
@@ -650,7 +650,11 @@ func (sc *syncContext) getSyncTasks() (_ syncTasks, successful bool) {
 
 	serverResCache := make(map[schema.GroupVersionKind]*metav1.APIResource)
 
-	cachedServerResourceForGroupVersionKind := func(sc *syncContext, task *syncTask) (serverRes *metav1.APIResource, err error) {
+	// check permissions
+	for _, task := range tasks {
+
+		var serverRes *metav1.APIResource
+		var err error
 
 		if val, ok := serverResCache[task.groupVersionKind()]; ok {
 			serverRes = val
@@ -664,13 +668,6 @@ func (sc *syncContext) getSyncTasks() (_ syncTasks, successful bool) {
 				serverResCache[task.groupVersionKind()] = serverRes
 			}
 		}
-		return serverRes, err
-	}
-
-	// check permissions
-	for _, task := range tasks {
-
-		serverRes, err := cachedServerResourceForGroupVersionKind(sc, task)
 
 		if err != nil {
 			// Special case for custom resources: if CRD is not yet known by the K8s API server,


### PR DESCRIPTION
Hello everyone, during my work on ArgoCD I noticed that quite a few methods in GitOps engine are quite large, and are not broken down into smaller, understandable methods. This has made it very hard for me to understand what the methods and functions do, as I had to keep very large information present in my mind, in order to understand them.

In this PR I have extracted blocks of code into hopefully more understandable, smaller methods and functions. For me the code is more readable now, because:

- I can understand each part independently from other part
- Names of methods provide some context as to what is being done
- Names of methods are more aligned with actual functionality provided, make it easier to create a connection between ArgoCD functionality and the code
- Less context pollution, because there is less variables present now

If this change is welcome I would like to do similar changes other methods as well. 

Note that there are few other changes which could be done, but I felt that I would need to write additional tests to cover this behavior, which is currently out of scope for me, as I am both only vaguely familiar with Golang, and even less so with this codebase.

