### PR TITLE
chore: speed up resolveResourceReferences

### DIFF
--- a/pkg/cache/references.go
+++ b/pkg/cache/references.go
@@ -3,11 +3,11 @@ package cache
 import (
 	"encoding/json"
 	"fmt"
-        "regexp"
 	v1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/types"
+	"regexp"
 
 	"github.com/argoproj/gitops-engine/pkg/utils/kube"
 )
@@ -17,7 +17,7 @@ func mightHaveInferredOwner(r *Resource) bool {
 	return r.Ref.GroupVersionKind().Group == "" && r.Ref.Kind == kube.PersistentVolumeClaimKind
 }
 
-func (c *clusterCache) resolveResourceReferences(un *unstructured.Unstructured) ([]metav1.OwnerReference, func(kube.ResourceKey) bool) {
+func (c clusterCache) resolveResourceReferences(un *unstructured.Unstructured) ([]metav1.OwnerReference, func(kube.ResourceKey) bool) {
 	var isInferredParentOf func(_ kube.ResourceKey) bool
 	ownerRefs := un.GetOwnerReferences()
 	gvk := un.GroupVersionKind()
@@ -25,7 +25,7 @@ func (c *clusterCache) resolveResourceReferences(un *unstructured.Unstructured) 
 	switch {
 
 	// Special case for endpoint. Remove after https://github.com/kubernetes/kubernetes/issues/28483 is fixed
-	case gvk.Group == "" && gvk.Kind == kube.EndpointsKind && len(un.GetOwnerReferences()) == 0:
+	case gvk.Group == "" && gvk.Kind == kube.EndpointsKind && len(ownerRefs) == 0:
 		ownerRefs = append(ownerRefs, metav1.OwnerReference{
 			Name:       un.GetName(),
 			Kind:       kube.ServiceKind,
@@ -33,7 +33,7 @@ func (c *clusterCache) resolveResourceReferences(un *unstructured.Unstructured) 
 		})
 
 	// Special case for Operator Lifecycle Manager ClusterServiceVersion:
-	case un.GroupVersionKind().Group == "operators.coreos.com" && un.GetKind() == "ClusterServiceVersion":
+	case gvk.Group == "operators.coreos.com" && gvk.Kind == "ClusterServiceVersion":
 		if un.GetAnnotations()["olm.operatorGroup"] != "" {
 			ownerRefs = append(ownerRefs, metav1.OwnerReference{
 				Name:       un.GetAnnotations()["olm.operatorGroup"],
@@ -43,12 +43,12 @@ func (c *clusterCache) resolveResourceReferences(un *unstructured.Unstructured) 
 		}
 
 	// Edge case: consider auto-created service account tokens as a child of service account objects
-	case un.GetKind() == kube.SecretKind && un.GroupVersionKind().Group == "":
+	case gvk.Kind == kube.SecretKind && gvk.Group == "":
 		if yes, ref := isServiceAccountTokenSecret(un); yes {
 			ownerRefs = append(ownerRefs, ref)
 		}
 
-	case (un.GroupVersionKind().Group == "apps" || un.GroupVersionKind().Group == "extensions") && un.GetKind() == kube.StatefulSetKind:
+	case (gvk.Group == "apps" || gvk.Group == "extensions") && gvk.Kind == kube.StatefulSetKind:
 		if refs, err := isStatefulSetChild(un); err != nil {
 			c.log.Error(err, fmt.Sprintf("Failed to extract StatefulSet %s/%s PVC references", un.GetNamespace(), un.GetName()))
 		} else {
@@ -74,7 +74,7 @@ func isStatefulSetChild(un *unstructured.Unstructured) (func(kube.ResourceKey) b
 	return func(key kube.ResourceKey) bool {
 		if key.Kind == kube.PersistentVolumeClaimKind && key.GroupKind().Group == "" {
 			for _, templ := range templates {
-				if match, _ := regexp.MatchString(fmt.Sprintf(`%s-%s-\d+$`, templ.Name, un.GetName()), key.Name); match  {
+				if match, _ := regexp.MatchString(fmt.Sprintf(`%s-%s-\d+$`, templ.Name, un.GetName()), key.Name); match {
 					return true
 				}
 			}

--- a/pkg/cache/references.go
+++ b/pkg/cache/references.go
@@ -17,7 +17,7 @@ func mightHaveInferredOwner(r *Resource) bool {
 	return r.Ref.GroupVersionKind().Group == "" && r.Ref.Kind == kube.PersistentVolumeClaimKind
 }
 
-func (c clusterCache) resolveResourceReferences(un *unstructured.Unstructured) ([]metav1.OwnerReference, func(kube.ResourceKey) bool) {
+func (c *clusterCache) resolveResourceReferences(un *unstructured.Unstructured) ([]metav1.OwnerReference, func(kube.ResourceKey) bool) {
 	var isInferredParentOf func(_ kube.ResourceKey) bool
 	ownerRefs := un.GetOwnerReferences()
 	gvk := un.GroupVersionKind()


### PR DESCRIPTION
Sitting at the airport with nothing better to do than micro-optimize stuff.

```
before: Benchmark_resolveResourceReferences-16           4676506               252.4 ns/op            82 B/op          3 allocs/op
after: Benchmark_resolveResourceReferences-16            8308146               143.6 ns/op            82 B/op          3 allocs/op
```

I didn't commit the benchmark code, because it's trivial and shouldn't be needed in the future. Here it is for inspection:

```go
func Benchmark_resolveResourceReferences(b *testing.B) {
	manifest := []byte(`
apiVersion: extensions/v1beta2
kind: Deployment
metadata:
  name: nginx-deployment
  labels:
    foo: bar
  uid: '123'
  ownerReferences:
  - apiVersion: apps/v1
    kind: StatefulSet
    name: sw-broker
    uid: '456'
`)
	obj := unstructured.Unstructured{}
	err := yaml.Unmarshal(manifest, &obj.Object)
	require.NoError(b, err)

	c := clusterCache{}

	b.ResetTimer()

	for i := 0; i < b.N; i++ {
		c.resolveResourceReferences(&obj)
	}
}
```