### PR TITLE
chore: avoid unnecessary json marshal

### DIFF
--- a/pkg/diff/diff.go
+++ b/pkg/diff/diff.go
@@ -673,22 +673,6 @@ func ThreeWayDiff(orig, config, live *unstructured.Unstructured) (*DiffResult, e
 	return buildDiffResult(predictedLiveBytes, liveBytes), nil
 }
 
-// stripTypeInformation strips any type information (e.g. float64 vs. int) from the unstructured
-// object by remarshalling the object. This is important for diffing since it will cause godiff
-// to report a false difference.
-func stripTypeInformation(un *unstructured.Unstructured) *unstructured.Unstructured {
-	unBytes, err := json.Marshal(un)
-	if err != nil {
-		panic(err)
-	}
-	var newUn unstructured.Unstructured
-	err = json.Unmarshal(unBytes, &newUn)
-	if err != nil {
-		panic(err)
-	}
-	return &newUn
-}
-
 // removeNamespaceAnnotation remove the namespace and an empty annotation map from the metadata.
 // The namespace field is present in live (namespaced) objects, but not necessarily present in
 // config or last-applied. This results in a diff which we don't care about. We delete the two so
@@ -1087,11 +1071,20 @@ func toString(val interface{}) string {
 // Remarshalling also strips any type information (e.g. float64 vs. int) from the unstructured
 // object. This is important for diffing since it will cause godiff to report a false difference.
 func remarshal(obj *unstructured.Unstructured, o options) *unstructured.Unstructured {
-	obj = stripTypeInformation(obj)
 	data, err := json.Marshal(obj)
 	if err != nil {
 		panic(err)
 	}
+
+	// Unmarshal again to strip type information (e.g. float64 vs. int) from the unstructured
+	// object. This is important for diffing since it will cause godiff to report a false difference.
+	var newUn unstructured.Unstructured
+	err = json.Unmarshal(data, &newUn)
+	if err != nil {
+		panic(err)
+	}
+	obj = &newUn
+
 	gvk := obj.GroupVersionKind()
 	item, err := scheme.Scheme.New(obj.GroupVersionKind())
 	if err != nil {

--- a/pkg/diff/diff_test.go
+++ b/pkg/diff/diff_test.go
@@ -1150,6 +1150,28 @@ spec:
 	t.Log(requestsAfter)
 	assert.Equal(t, float64(0.2), requestsBefore["cpu"])
 	assert.Equal(t, "200m", requestsAfter["cpu"])
+
+	t.Run("from float", func(t *testing.T) {
+		// use a plain float, not float64
+		un.Object["spec"].(map[string]interface{})["containers"].([]interface{})[0].(map[string]interface{})["resources"].(map[string]interface{})["requests"].(map[string]interface{})["cpu"] = 0.2
+		newUn := remarshal(&un, applyOptions(diffOptionsForTest()))
+		requestsAfter := newUn.Object["spec"].(map[string]interface{})["containers"].([]interface{})[0].(map[string]interface{})["resources"].(map[string]interface{})["requests"].(map[string]interface{})
+		assert.Equal(t, "200m", requestsAfter["cpu"])
+	})
+
+	t.Run("from string", func(t *testing.T) {
+		un.Object["spec"].(map[string]interface{})["containers"].([]interface{})[0].(map[string]interface{})["resources"].(map[string]interface{})["requests"].(map[string]interface{})["cpu"] = "200m"
+		newUn := remarshal(&un, applyOptions(diffOptionsForTest()))
+		requestsAfter := newUn.Object["spec"].(map[string]interface{})["containers"].([]interface{})[0].(map[string]interface{})["resources"].(map[string]interface{})["requests"].(map[string]interface{})
+		assert.Equal(t, "200m", requestsAfter["cpu"])
+	})
+
+	t.Run("from invalid", func(t *testing.T) {
+		un.Object["spec"].(map[string]interface{})["containers"].([]interface{})[0].(map[string]interface{})["resources"].(map[string]interface{})["requests"].(map[string]interface{})["cpu"] = "invalid"
+		newUn := remarshal(&un, applyOptions(diffOptionsForTest()))
+		requestsAfter := newUn.Object["spec"].(map[string]interface{})["containers"].([]interface{})[0].(map[string]interface{})["resources"].(map[string]interface{})["requests"].(map[string]interface{})
+		assert.Equal(t, "invalid", requestsAfter["cpu"])
+	})
 }
 
 func ExampleDiff() {

--- a/pkg/diff/diff_test.go
+++ b/pkg/diff/diff_test.go
@@ -1127,6 +1127,14 @@ metadata:
 }
 
 func TestRemarshalResources(t *testing.T) {
+	getRequests := func(un *unstructured.Unstructured) map[string]interface{} {
+		return un.Object["spec"].(map[string]interface{})["containers"].([]interface{})[0].(map[string]interface{})["resources"].(map[string]interface{})["requests"].(map[string]interface{})
+	}
+
+	setRequests := func(un *unstructured.Unstructured, requests map[string]interface{}) {
+		un.Object["spec"].(map[string]interface{})["containers"].([]interface{})[0].(map[string]interface{})["resources"].(map[string]interface{})["requests"] = requests
+	}
+
 	manifest := []byte(`
 apiVersion: v1
 kind: Pod
@@ -1142,36 +1150,27 @@ spec:
 `)
 	un := unstructured.Unstructured{}
 	err := yaml.Unmarshal(manifest, &un)
-	assert.NoError(t, err)
-	requestsBefore := un.Object["spec"].(map[string]interface{})["containers"].([]interface{})[0].(map[string]interface{})["resources"].(map[string]interface{})["requests"].(map[string]interface{})
-	t.Log(requestsBefore)
-	newUn := remarshal(&un, applyOptions(diffOptionsForTest()))
-	requestsAfter := newUn.Object["spec"].(map[string]interface{})["containers"].([]interface{})[0].(map[string]interface{})["resources"].(map[string]interface{})["requests"].(map[string]interface{})
-	t.Log(requestsAfter)
-	assert.Equal(t, float64(0.2), requestsBefore["cpu"])
-	assert.Equal(t, "200m", requestsAfter["cpu"])
+	require.NoError(t, err)
 
-	t.Run("from float", func(t *testing.T) {
-		// use a plain float, not float64
-		un.Object["spec"].(map[string]interface{})["containers"].([]interface{})[0].(map[string]interface{})["resources"].(map[string]interface{})["requests"].(map[string]interface{})["cpu"] = 0.2
-		newUn := remarshal(&un, applyOptions(diffOptionsForTest()))
-		requestsAfter := newUn.Object["spec"].(map[string]interface{})["containers"].([]interface{})[0].(map[string]interface{})["resources"].(map[string]interface{})["requests"].(map[string]interface{})
-		assert.Equal(t, "200m", requestsAfter["cpu"])
-	})
+	testCases := []struct {
+		name        string
+		cpu         any
+		expectedCPU any
+	}{
+		{"from float", 0.2, "200m"},
+		{"from float64", float64(0.2), "200m"},
+		{"from string", "0.2", "200m"},
+		{"from invalid", "invalid", "invalid"},
+	}
 
-	t.Run("from string", func(t *testing.T) {
-		un.Object["spec"].(map[string]interface{})["containers"].([]interface{})[0].(map[string]interface{})["resources"].(map[string]interface{})["requests"].(map[string]interface{})["cpu"] = "200m"
-		newUn := remarshal(&un, applyOptions(diffOptionsForTest()))
-		requestsAfter := newUn.Object["spec"].(map[string]interface{})["containers"].([]interface{})[0].(map[string]interface{})["resources"].(map[string]interface{})["requests"].(map[string]interface{})
-		assert.Equal(t, "200m", requestsAfter["cpu"])
-	})
-
-	t.Run("from invalid", func(t *testing.T) {
-		un.Object["spec"].(map[string]interface{})["containers"].([]interface{})[0].(map[string]interface{})["resources"].(map[string]interface{})["requests"].(map[string]interface{})["cpu"] = "invalid"
-		newUn := remarshal(&un, applyOptions(diffOptionsForTest()))
-		requestsAfter := newUn.Object["spec"].(map[string]interface{})["containers"].([]interface{})[0].(map[string]interface{})["resources"].(map[string]interface{})["requests"].(map[string]interface{})
-		assert.Equal(t, "invalid", requestsAfter["cpu"])
-	})
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			setRequests(&un, map[string]interface{}{"cpu": tc.cpu})
+			newUn := remarshal(&un, applyOptions(diffOptionsForTest()))
+			requestsAfter := getRequests(newUn)
+			assert.Equal(t, tc.expectedCPU, requestsAfter["cpu"])
+		})
+	}
 }
 
 func ExampleDiff() {


### PR DESCRIPTION
We have a utility function `stripTypeInformation` that json marshals and then unmarshals an unstructured in order to remove type information before diffing.

The only caller of `stripTypeInformation` immediately JSON-marshals the new unstructured, i.e. we JSON-marshal the unstructured object twice. Instead of having a separate utility function, we can take advantage of the `remarshal` function's marshaled copy of the unstructured to unmarshal and perform type-stripping.

I ran a 120s memory profile on an Intuit app controller. `remarshal` was responsible for 2% of the memory use. A 120s CPU profile showed `remarshal` as responsible for 3% of the CPU use. So I think the function is worth optimizing.

Testing with a medium-size manifest (about 100 lines) showed the following difference in benchmark:

```
before: Benchmark_remarshal-16              7328            155438 ns/op           90839 B/op       1338 allocs/op
after:  Benchmark_remarshal-16             10000            119162 ns/op           77498 B/op       1090 allocs/op
```

So 15% less memory and 23% less CPU time. The difference should be more dramatic with larger manifests.

I didn't commit the benchmark code, but here it is for reference:

```go
func Benchmark_remarshal(b *testing.B) {
	manifest := []byte(`
apiVersion: v1
kind: Service
metadata:
  annotations:
    argocd.argoproj.io/sync-options: ServerSideApply=true
    kubectl.kubernetes.io/last-applied-configuration: >
      {"apiVersion":"v1","kind":"Service","metadata":{"annotations":{"argocd.argoproj.io/sync-options":"ServerSideApply=true"},"name":"multiple-protocol-port-svc","namespace":"default"},"spec":{"ports":[{"name":"rtmpk","port":1986,"protocol":"UDP","targetPort":1986},{"name":"rtmp","port":1935,"protocol":"TCP","targetPort":1935},{"name":"rtmpq","port":1935,"protocol":"UDP","targetPort":1935}]}}
  creationTimestamp: '2022-06-24T19:37:02Z'
  labels:
    app.kubernetes.io/instance: big-crd
  managedFields:
    - apiVersion: v1
      fieldsType: FieldsV1
      fieldsV1:
        'f:metadata':
          'f:annotations':
            'f:argocd.argoproj.io/sync-options': {}
          'f:labels':
            'f:app.kubernetes.io/instance': {}
        'f:spec':
          'f:ports':
            'k:{"port":1935,"protocol":"TCP"}':
              .: {}
              'f:name': {}
              'f:port': {}
              'f:targetPort': {}
            'k:{"port":1986,"protocol":"UDP"}':
              .: {}
              'f:name': {}
              'f:port': {}
              'f:protocol': {}
              'f:targetPort': {}
            'k:{"port":443,"protocol":"TCP"}':
              .: {}
              'f:name': {}
              'f:port': {}
              'f:targetPort': {}
          'f:type': {}
      manager: argocd-controller
      operation: Apply
      time: '2022-06-30T16:28:09Z'
    - apiVersion: v1
      fieldsType: FieldsV1
      fieldsV1:
        'f:metadata':
          'f:annotations':
            .: {}
            'f:kubectl.kubernetes.io/last-applied-configuration': {}
        'f:spec':
          'f:internalTrafficPolicy': {}
          'f:ports':
            .: {}
            'k:{"port":1935,"protocol":"TCP"}':
              .: {}
              'f:name': {}
              'f:port': {}
              'f:protocol': {}
              'f:targetPort': {}
            'k:{"port":1986,"protocol":"UDP"}':
              .: {}
              'f:name': {}
              'f:port': {}
              'f:protocol': {}
              'f:targetPort': {}
          'f:sessionAffinity': {}
      manager: kubectl-client-side-apply
      operation: Update
      time: '2022-06-25T04:18:10Z'
    - apiVersion: v1
      fieldsType: FieldsV1
      fieldsV1:
        'f:status':
          'f:loadBalancer':
            'f:ingress': {}
      manager: kube-vpnkit-forwarder
      operation: Update
      subresource: status
      time: '2022-06-29T12:36:34Z'
  name: multiple-protocol-port-svc
  namespace: default
  resourceVersion: '2138591'
  uid: af42e800-bd33-4412-bc77-d204d298613d
spec:
  clusterIP: 10.111.193.74
  clusterIPs:
    - 10.111.193.74
  externalTrafficPolicy: Cluster
  ipFamilies:
    - IPv4
  ipFamilyPolicy: SingleStack
  ports:
    - name: rtmpk
      nodePort: 31648
      port: 1986
      protocol: UDP
      targetPort: 1986
    - name: rtmp
      nodePort: 30018
      port: 1935
      protocol: TCP
      targetPort: 1935
    - name: https
      nodePort: 31975
      port: 443
      protocol: TCP
      targetPort: 443
  sessionAffinity: None
  type: NodePort
status:
  loadBalancer: {}
`)
	un := unstructured.Unstructured{}
	err := yaml.Unmarshal(manifest, &un)
	require.NoError(b, err)
	opts := applyOptions(diffOptionsForTest())

	b.ResetTimer()

	for i := 0; i < b.N; i++ {
		remarshal(&un, opts)
	}
}
```
