### PR TITLE
chore: avoid unnecessary json unmarshal

### DIFF
--- a/pkg/diff/diff.go
+++ b/pkg/diff/diff.go
@@ -664,12 +664,6 @@ func ThreeWayDiff(orig, config, live *unstructured.Unstructured) (*DiffResult, e
 		}
 	}
 
-	predictedLive := &unstructured.Unstructured{}
-	err = json.Unmarshal(predictedLiveBytes, predictedLive)
-	if err != nil {
-		return nil, err
-	}
-
 	return buildDiffResult(predictedLiveBytes, liveBytes), nil
 }
 


### PR DESCRIPTION
As far as I can tell, the only purpose these lines serve is to confirm that `predictedLiveBytes` is valid JSON. But at this point in the code, I don't think we have any reason to believe that the JSON is _not_ valid. We're relying on solid libraries to produce that JSON. Even if the JSON were somehow invalid, I'm not sure there's any value in validating it here versus where it's eventually used.

Here's the benchmark output:

```
before: Benchmark_threeWayMergePatch-16            21823             53131 ns/op           41018 B/op        861 allocs/op
after:  Benchmark_threeWayMergePatch-16            22926             52559 ns/op           39072 B/op        810 allocs/op
```

It's a small but not insignificant memory and compute win. I think the benefits increase as the JSON size increases.

And the benchmark code:

```go
func Benchmark_threeWayMergePatch(b *testing.B) {
	orig := []byte(`
apiVersion: v1
kind: Service
metadata:
  name: my-service
  namespace: default
`)
	config := []byte(`
apiVersion: v1
kind: Service
metadata:
  name: my-service
  namespace: default
`)
	live := []byte(`
apiVersion: v1
kind: Service
metadata:
  name: my-service
  namespace: default
`)

	origUnstructured := unstructured.Unstructured{}
	err := yaml.Unmarshal(orig, &origUnstructured)
	require.NoError(b, err)
	configUnstructured := unstructured.Unstructured{}
	err = yaml.Unmarshal(config, &configUnstructured)
	require.NoError(b, err)
	liveUnstructured := unstructured.Unstructured{}
	err = yaml.Unmarshal(live, &liveUnstructured)
	require.NoError(b, err)

	b.ResetTimer()

	for i := 0; i < b.N; i++ {
		_, err := ThreeWayDiff(&origUnstructured, &configUnstructured, &liveUnstructured)
		require.NoError(b, err)
	}
}
```