### PR TITLE
chore(deps): upgrade go version in dockerfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 .idea
 coverage.out
 vendor/
+.tool-versions

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,3 +1,3 @@
-run:
-  skip-files:
-    - "pkg/diff/internal/fieldmanager/borrowed_.+\\.go$"
+issues:
+  exclude-files:
+    - "pkg/diff/internal/fieldmanager/borrowed_.*\\.go$"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.17 as builder
+FROM golang:1.22 AS builder
 
 WORKDIR /src
 
@@ -12,5 +12,5 @@ COPY . .
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags="-w -s" -o /dist/gitops ./agent
 
 
-FROM alpine/git:v2.24.3
+FROM alpine/git:v2.45.2
 COPY --from=builder /dist/gitops /usr/local/bin/gitops


### PR DESCRIPTION
### Changes

I noticed the version difference between the go.mod and Dockerfile in the repo (1.17 vs 1.22).  Fixed a few other things also, like upgrading the version of the alpine/git image to the latest version.

- [x] fix warnings about case of `as` to `AS` in Dockerfile
  - `FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 1)`
- [x] update Dockerfile Go version from 1.17 to 1.22 to match go.mod
- [x] upgrade alipine/git image version to latest, current was 4 years old
  - -from alpine/git:v2.24.3 (4 years old) to alpine/git:v2.45.2
- [x] fix warning with linting [happening in current ci runs](https://github.com/argoproj/gitops-engine/actions/runs/11884564176/job/33112931157#step:6:23)
  - `WARN [config_reader] The configuration option 'run.skip-files' is deprecated, please use 'issues.exclude-files'`
- [x] add .tool-versions (asdf) to .gitignore

### Tests

Test pass locally.  No new features really added so unsure if new tests are needed.

### Questions

Do I need to run this against an argo-cd instance or with argo-cd test suite to ensure we're good?