### PR TITLE
fix: Server side diff now works correctly with some fields removal

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	k8s.io/kube-openapi v0.0.0-20240228011516-70dd3763d340
 	k8s.io/kubectl v0.31.2
 	k8s.io/kubernetes v1.31.0
-	sigs.k8s.io/structured-merge-diff/v4 v4.4.3
+	sigs.k8s.io/structured-merge-diff/v4 v4.4.4-0.20241211184406-7bf59b3d70ee
 	sigs.k8s.io/yaml v1.4.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -328,7 +328,7 @@ sigs.k8s.io/kustomize/api v0.17.2 h1:E7/Fjk7V5fboiuijoZHgs4aHuexi5Y2loXlVOAVAG5g
 sigs.k8s.io/kustomize/api v0.17.2/go.mod h1:UWTz9Ct+MvoeQsHcJ5e+vziRRkwimm3HytpZgIYqye0=
 sigs.k8s.io/kustomize/kyaml v0.17.1 h1:TnxYQxFXzbmNG6gOINgGWQt09GghzgTP6mIurOgrLCQ=
 sigs.k8s.io/kustomize/kyaml v0.17.1/go.mod h1:9V0mCjIEYjlXuCdYsSXvyoy2BTsLESH7TlGV81S282U=
-sigs.k8s.io/structured-merge-diff/v4 v4.4.3 h1:sCP7Vv3xx/CWIuTPVN38lUPx0uw0lcLfzaiDa8Ja01A=
-sigs.k8s.io/structured-merge-diff/v4 v4.4.3/go.mod h1:N8f93tFZh9U6vpxwRArLiikrE5/2tiu1w1AGfACIGE4=
+sigs.k8s.io/structured-merge-diff/v4 v4.4.4-0.20241211184406-7bf59b3d70ee h1:ipT2c6nEOdAfBwiwW1oI0mkrlPabbXEFmJBrg6B+OR8=
+sigs.k8s.io/structured-merge-diff/v4 v4.4.4-0.20241211184406-7bf59b3d70ee/go.mod h1:N8f93tFZh9U6vpxwRArLiikrE5/2tiu1w1AGfACIGE4=
 sigs.k8s.io/yaml v1.4.0 h1:Mk1wCc2gy/F0THH0TAp1QYyJNzRm2KCLy3o5ASXVI5E=
 sigs.k8s.io/yaml v1.4.0/go.mod h1:Ejl7/uTz7PSA4eKMyQCUTnhZYNmLIl+5c2lQPGR2BPY=

--- a/pkg/diff/diff.go
+++ b/pkg/diff/diff.go
@@ -258,13 +258,7 @@ func removeWebhookMutation(predictedLive, live *unstructured.Unstructured, gvkPa
 	}
 
 	if comparison.Modified != nil && !comparison.Modified.Empty() {
-		comparisonModifiedForMerge := comparison.Modified
-		typedPredictedLiveFieldSet, err := typedPredictedLive.ToFieldSet()
-		if err != nil {
-			return nil, fmt.Errorf("error reverting webhook modified fields in predicted live resource: %s", err)
-		}
-		appendKeyFieldsToRhs(typedPredictedLiveFieldSet, comparisonModifiedForMerge)
-		liveModValues := typedLive.ExtractItems(comparisonModifiedForMerge)
+		liveModValues := typedLive.ExtractItems(comparison.Modified, typed.WithAppendKeyFields())
 		// revert modified fields not owned by any manager
 		typedPredictedLive, err = typedPredictedLive.Merge(liveModValues)
 		if err != nil {
@@ -273,13 +267,7 @@ func removeWebhookMutation(predictedLive, live *unstructured.Unstructured, gvkPa
 	}
 
 	if comparison.Removed != nil && !comparison.Removed.Empty() {
-		comparisonRemovedForMerge := comparison.Removed
-		typedPredictedLiveFieldSet, err := typedPredictedLive.ToFieldSet()
-		if err != nil {
-			return nil, fmt.Errorf("error reverting webhook removed fields in predicted live resource: %s", err)
-		}
-		appendKeyFieldsToRhs(typedPredictedLiveFieldSet, comparisonRemovedForMerge)
-		liveRmValues := typedLive.ExtractItems(comparisonRemovedForMerge)
+		liveRmValues := typedLive.ExtractItems(comparison.Removed, typed.WithAppendKeyFields())
 		// revert removed fields not owned by any manager
 		typedPredictedLive, err = typedPredictedLive.Merge(liveRmValues)
 		if err != nil {
@@ -293,31 +281,6 @@ func removeWebhookMutation(predictedLive, live *unstructured.Unstructured, gvkPa
 		return nil, fmt.Errorf("error converting live typedValue: expected map got %T", plu)
 	}
 	return &unstructured.Unstructured{Object: pl}, nil
-}
-
-// appendKeyFieldsToRhs appends the key fields like "name" to the rhs elements which have some entries keyed by those fields.
-// The fields are only appended if they are present in lhs as well, otherwise assuming they have a default value not needed
-// to be specified explicitly.
-// This is needed to merge properly, see https://github.com/argoproj/argo-cd/issues/20792.
-func appendKeyFieldsToRhs(lhs *fieldpath.Set, rhs *fieldpath.Set) {
-	keyFieldPaths := []fieldpath.Path{}
-	rhs.Iterate(func(path fieldpath.Path) {
-		for i := 0; i < len(path); i++ {
-			if path[i].Key != nil {
-				for _, keyField := range *path[i].Key {
-					pathPartCopy := make([]fieldpath.PathElement, i+1)
-					copy(pathPartCopy, path[:i+1])
-					newPath := append(pathPartCopy, fieldpath.PathElement{FieldName: &keyField.Name})
-					keyFieldPaths = append(keyFieldPaths, newPath)
-				}
-			}
-		}
-	})
-	for _, path := range keyFieldPaths {
-		if !rhs.Has(path) && lhs.Has(path) {
-			rhs.Insert(path)
-		}
-	}
 }
 
 func jsonStrToUnstructured(jsonString string) (*unstructured.Unstructured, error) {

--- a/pkg/diff/diff_test.go
+++ b/pkg/diff/diff_test.go
@@ -28,8 +28,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/managedfields"
 	"k8s.io/klog/v2/textlogger"
 	openapiproto "k8s.io/kube-openapi/pkg/util/proto"
-	"sigs.k8s.io/structured-merge-diff/v4/fieldpath"
-	"sigs.k8s.io/structured-merge-diff/v4/value"
 	"sigs.k8s.io/yaml"
 )
 
@@ -1344,73 +1342,6 @@ spec:
 			assert.Equal(t, tc.expectedCPU, requestsAfter["cpu"])
 		})
 	}
-}
-
-func TestAppendKeyFieldsToRhs(t *testing.T) {
-	// Paths for the key field "name", simulating a key field with no default value.
-	lhsPath1, err := fieldpath.MakePath(
-		"spec",
-		"containers",
-		&value.FieldList{value.Field{Name: "name", Value: value.NewValueInterface("test1")}},
-		"name",
-	)
-	assert.NoError(t, err)
-	lhsPath2, err := fieldpath.MakePath(
-		"spec",
-		"containers",
-		&value.FieldList{value.Field{Name: "name", Value: value.NewValueInterface("test2")}},
-		"name",
-	)
-	assert.NoError(t, err)
-	lhs := fieldpath.NewSet(lhsPath1, lhsPath2)
-
-	rhsPath1, err := fieldpath.MakePath(
-		"spec",
-		"containers",
-		&value.FieldList{value.Field{Name: "name", Value: value.NewValueInterface("test1")}},
-		"resources",
-	)
-	assert.NoError(t, err)
-	// Has some key fields which are assumed to have default values like "protocol"
-	rhsPath2, err := fieldpath.MakePath(
-		"spec",
-		"containers",
-		&value.FieldList{value.Field{Name: "name", Value: value.NewValueInterface("test2")}},
-		"ports",
-		&value.FieldList{
-			value.Field{Name: "containerPort", Value: value.NewValueInterface(8080)},
-			value.Field{Name: "protocol", Value: value.NewValueInterface("TCP")},
-		},
-		"containerPort",
-	)
-	assert.NoError(t, err)
-
-	rhs := fieldpath.NewSet(rhsPath1, rhsPath2)
-
-	appendKeyFieldsToRhs(lhs, rhs)
-
-	assert.Equal(t, rhs.Size(), 4)
-	assert.True(t, rhs.Has(rhsPath1))
-	assert.True(t, rhs.Has(rhsPath2))
-
-	// The paths for the field "name" should be added, but not "protocol".
-	rhsPath3, err := fieldpath.MakePath(
-		"spec",
-		"containers",
-		&value.FieldList{value.Field{Name: "name", Value: value.NewValueInterface("test1")}},
-		"name",
-	)
-	assert.NoError(t, err)
-	rhsPath4, err := fieldpath.MakePath(
-		"spec",
-		"containers",
-		&value.FieldList{value.Field{Name: "name", Value: value.NewValueInterface("test2")}},
-		"name",
-	)
-	assert.NoError(t, err)
-
-	assert.True(t, rhs.Has(rhsPath3))
-	assert.True(t, rhs.Has(rhsPath4))
 }
 
 func ExampleDiff() {

--- a/pkg/diff/testdata/data.go
+++ b/pkg/diff/testdata/data.go
@@ -24,6 +24,15 @@ var (
 	//go:embed smd-deploy-config.yaml
 	DeploymentConfigYAML string
 
+	//go:embed smd-deploy2-live.yaml
+	Deployment2LiveYAML string
+
+	//go:embed smd-deploy2-config.yaml
+	Deployment2ConfigYAML string
+
+	//go:embed smd-deploy2-predicted-live.json
+	Deployment2PredictedLiveJSONSSD string
+
 	// OpenAPIV2Doc is a binary representation of the openapi
 	// document available in a given k8s instance. To update
 	// this file the following commands can be executed:

--- a/pkg/diff/testdata/smd-deploy2-config.yaml
+++ b/pkg/diff/testdata/smd-deploy2-config.yaml
@@ -1,0 +1,36 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: missing
+    applications.argoproj.io/app-name: nginx
+    something-else: bla
+  name: nginx-deployment
+  namespace: default
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+        applications.argoproj.io/app-name: nginx
+    spec:
+      containers:
+        - image: 'nginx:1.23.1'
+          imagePullPolicy: Never
+          livenessProbe:
+            exec:
+              command:
+                - cat
+                - non-existent-file
+            initialDelaySeconds: 5
+            periodSeconds: 180
+          name: nginx
+          ports:
+            - containerPort: 8081
+              protocol: UDP
+            - containerPort: 80
+              protocol: TCP

--- a/pkg/diff/testdata/smd-deploy2-live.yaml
+++ b/pkg/diff/testdata/smd-deploy2-live.yaml
@@ -1,0 +1,161 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    deployment.kubernetes.io/revision: '1'
+  creationTimestamp: '2022-09-18T23:50:25Z'
+  generation: 1
+  labels:
+    app: missing
+    applications.argoproj.io/app-name: nginx
+    something-else: bla
+  managedFields:
+    - apiVersion: apps/v1
+      fieldsType: FieldsV1
+      fieldsV1:
+        'f:metadata':
+          'f:labels':
+            'f:app': {}
+            'f:applications.argoproj.io/app-name': {}
+            'f:something-else': {}
+        'f:spec':
+          'f:replicas': {}
+          'f:selector': {}
+          'f:template':
+            'f:metadata':
+              'f:labels':
+                'f:app': {}
+                'f:applications.argoproj.io/app-name': {}
+            'f:spec':
+              'f:containers':
+                'k:{"name":"nginx"}':
+                  .: {}
+                  'f:image': {}
+                  'f:imagePullPolicy': {}
+                  'f:livenessProbe':
+                    'f:exec':
+                      'f:command': {}
+                    'f:initialDelaySeconds': {}
+                    'f:periodSeconds': {}
+                  'f:name': {}
+                  'f:ports':
+                    'k:{"containerPort":80,"protocol":"TCP"}':
+                      .: {}
+                      'f:containerPort': {}
+                      'f:protocol': {}
+                  'f:resources':
+                    'f:requests':
+                      'f:cpu': {}
+                      'f:memory': {}
+      manager: argocd-controller
+      operation: Apply
+      time: '2022-09-18T23:50:25Z'
+    - apiVersion: apps/v1
+      fieldsType: FieldsV1
+      fieldsV1:
+        'f:metadata':
+          'f:annotations':
+            .: {}
+            'f:deployment.kubernetes.io/revision': {}
+        'f:status':
+          'f:availableReplicas': {}
+          'f:conditions':
+            .: {}
+            'k:{"type":"Available"}':
+              .: {}
+              'f:lastTransitionTime': {}
+              'f:lastUpdateTime': {}
+              'f:message': {}
+              'f:reason': {}
+              'f:status': {}
+              'f:type': {}
+            'k:{"type":"Progressing"}':
+              .: {}
+              'f:lastTransitionTime': {}
+              'f:lastUpdateTime': {}
+              'f:message': {}
+              'f:reason': {}
+              'f:status': {}
+              'f:type': {}
+          'f:observedGeneration': {}
+          'f:readyReplicas': {}
+          'f:replicas': {}
+          'f:updatedReplicas': {}
+      manager: kube-controller-manager
+      operation: Update
+      subresource: status
+      time: '2022-09-23T18:30:59Z'
+  name: nginx-deployment
+  namespace: default
+  resourceVersion: '7492752'
+  uid: 731f7434-d3d9-47fa-b179-d9368a84f7c9
+spec:
+  progressDeadlineSeconds: 600
+  replicas: 2
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app: nginx
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: nginx
+        applications.argoproj.io/app-name: nginx
+    spec:
+      containers:
+        - image: 'nginx:1.23.1'
+          imagePullPolicy: Never
+          livenessProbe:
+            exec:
+              command:
+                - cat
+                - non-existent-file
+            failureThreshold: 3
+            initialDelaySeconds: 5
+            periodSeconds: 180
+            successThreshold: 1
+            timeoutSeconds: 1
+          name: nginx
+          ports:
+            - containerPort: 80
+              protocol: TCP
+            - containerPort: 8080
+              protocol: TCP
+            - containerPort: 8081
+              protocol: UDP
+          resources:
+            requests:
+              memory: 512Mi
+              cpu: 500m
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      terminationGracePeriodSeconds: 30
+status:
+  availableReplicas: 2
+  conditions:
+    - lastTransitionTime: '2022-09-18T23:50:25Z'
+      lastUpdateTime: '2022-09-18T23:50:26Z'
+      message: ReplicaSet "nginx-deployment-6d68ff5f86" has successfully progressed.
+      reason: NewReplicaSetAvailable
+      status: 'True'
+      type: Progressing
+    - lastTransitionTime: '2022-09-23T18:30:59Z'
+      lastUpdateTime: '2022-09-23T18:30:59Z'
+      message: Deployment has minimum availability.
+      reason: MinimumReplicasAvailable
+      status: 'True'
+      type: Available
+  observedGeneration: 1
+  readyReplicas: 2
+  replicas: 2
+  updatedReplicas: 2

--- a/pkg/diff/testdata/smd-deploy2-predicted-live.json
+++ b/pkg/diff/testdata/smd-deploy2-predicted-live.json
@@ -1,0 +1,124 @@
+{
+    "apiVersion": "apps/v1",
+    "kind": "Deployment",
+    "metadata": {
+        "labels": {
+            "app": "missing",
+            "applications.argoproj.io/app-name": "nginx",
+            "something-else": "bla"
+        },
+        "name": "nginx-deployment",
+        "namespace": "default",
+        "managedFields": [
+            {
+                "apiVersion": "apps/v1",
+                "fieldsType": "FieldsV1",
+                "fieldsV1": {
+                    "f:metadata": {
+                        "f:labels": {
+                            "f:app": {},
+                            "f:applications.argoproj.io/app-name": {},
+                            "f:something-else": {}
+                        }
+                    },
+                    "f:spec": {
+                        "f:replicas": {},
+                        "f:selector": {},
+                        "f:template": {
+                            "f:metadata": {
+                                "f:labels": {
+                                    "f:app": {},
+                                    "f:applications.argoproj.io/app-name": {}
+                                }
+                            },
+                            "f:spec": {
+                                "f:containers": {
+                                    "k:{\"name\":\"nginx\"}": {
+                                        ".": {},
+                                        "f:image": {},
+                                        "f:imagePullPolicy": {},
+                                        "f:livenessProbe": {
+                                            "f:exec": {
+                                                "f:command": {}
+                                            },
+                                            "f:initialDelaySeconds": {},
+                                            "f:periodSeconds": {}
+                                        },
+                                        "f:name": {},
+                                        "f:ports": {
+                                            "k:{\"containerPort\":80,\"protocol\":\"TCP\"}": {
+                                                ".": {},
+                                                "f:containerPort": {},
+                                                "f:protocol": {}
+                                            }
+                                        },
+                                        "f:resources": {
+                                            "f:requests": {
+                                                "f:cpu": {},
+                                                "f:memory": {}
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "manager": "argocd-controller",
+                "operation": "Apply",
+                "time": "2022-09-18T23:50:25Z"
+            }
+        ]
+    },
+    "spec": {
+        "replicas": 2,
+        "selector": {
+            "matchLabels": {
+                "app": "nginx"
+            }
+        },
+        "template": {
+            "metadata": {
+                "labels": {
+                    "app": "nginx",
+                    "applications.argoproj.io/app-name": "nginx"
+                }
+            },
+            "spec": {
+                "containers": [
+                    {
+                        "image": "nginx:1.23.1",
+                        "imagePullPolicy": "Never",
+                        "livenessProbe": {
+                            "exec": {
+                                "command": [
+                                    "cat",
+                                    "non-existent-file"
+                                ]
+                            },
+                            "initialDelaySeconds": 5,
+                            "periodSeconds": 180
+                        },
+                        "name": "nginx",
+                        "ports": [
+                            {
+                                "containerPort": 8081,
+                                "protocol": "UDP"
+                            },
+                            {
+                                "containerPort": 80,
+                                "protocol": "TCP"
+                            }
+                        ],
+                        "resources": {
+                            "requests": {
+                                "memory": "512Mi",
+                                "cpu": "500m"
+                            }
+                        }
+                    }
+                ]
+            }
+        }
+    }
+}

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,2 @@
+# Exclude test manifests from analysis
+sonar.kubernetes.exclusions=pkg/diff/testdata/**

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,2 +1,2 @@
 # Exclude test manifests from analysis
-sonar.kubernetes.exclusions=pkg/diff/testdata/**
+sonar.exclusions=pkg/diff/testdata/**


### PR DESCRIPTION
Helps with https://github.com/argoproj/argo-cd/issues/20792

Removed and modified sets may only contain the fields that changed, not including key fields like "name". This can cause merge to fail, since it expects those fields to be present if they are present in the predicted live. Fortunately, structured merge diff folks have added an option to extracting items to add key fields, and we are going to use that.

Failure of the new test before the fix
```
            	Error:      	Received unexpected error:
            	            	error removing non config mutations for resource Deployment/nginx-deployment: error reverting webhook removed fields in predicted live resource: .spec.template.spec.containers: element 0: associative list with keys has an element that omits key field "name" (and doesn't have default value)
            	Test:       	TestServerSideDiff/will_test_removing_some_field_with_undoing_changes_done_by_webhook
```