### PR TITLE
feat: return images from resources when sync occurs

### DIFF
--- a/pkg/sync/common/types.go
+++ b/pkg/sync/common/types.go
@@ -136,7 +136,9 @@ func NewHookDeletePolicy(p string) (HookDeletePolicy, bool) {
 type ResourceSyncResult struct {
 	// holds associated resource key
 	ResourceKey kube.ResourceKey
-	// holds the images associated with the resource
+	// Images holds the images associated with the resource. These images are collected on a best-effort basis
+	// from fields used by known workload resources. This does not necessarily reflect the exact list of images
+	// used by workloads in the application.
 	Images []string
 	// holds resource version
 	Version string

--- a/pkg/sync/common/types.go
+++ b/pkg/sync/common/types.go
@@ -136,6 +136,8 @@ func NewHookDeletePolicy(p string) (HookDeletePolicy, bool) {
 type ResourceSyncResult struct {
 	// holds associated resource key
 	ResourceKey kube.ResourceKey
+	// holds the images associated with the resource
+	Images []string
 	// holds resource version
 	Version string
 	// holds the execution order

--- a/pkg/sync/sync_context.go
+++ b/pkg/sync/sync_context.go
@@ -1376,6 +1376,7 @@ func (sc *syncContext) setResourceResult(task *syncTask, syncStatus common.Resul
 
 	res := common.ResourceSyncResult{
 		ResourceKey: kubeutil.GetResourceKey(task.obj()),
+		Images:      kubeutil.GetResourceImages(task.obj()),
 		Version:     task.version(),
 		Status:      task.syncStatus,
 		Message:     task.message,

--- a/pkg/sync/sync_context_test.go
+++ b/pkg/sync/sync_context_test.go
@@ -7,12 +7,14 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
+	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
@@ -2060,4 +2062,51 @@ func TestWaitForCleanUpBeforeNextWave(t *testing.T) {
 	assert.Equal(t, synccommon.ResultCodePruned, result[0].Status)
 	assert.Equal(t, synccommon.ResultCodePruned, result[1].Status)
 	assert.Equal(t, synccommon.ResultCodePruned, result[2].Status)
+}
+
+func BenchmarkSync(b *testing.B) {
+	podManifest := `{
+	  "apiVersion": "v1",
+	  "kind": "Pod",
+	  "metadata": {
+		"name": "my-pod"
+	  },
+	  "spec": {
+		"containers": [
+		${containers}
+		]
+	  }
+	}`
+	container := `{
+			"image": "nginx:1.7.9",
+			"name": "nginx",
+			"resources": {
+			  "requests": {
+				"cpu": "0.2"
+			  }
+			}
+		  }`
+
+	maxContainers := 10
+	for i := 0; i < b.N; i++ {
+		b.StopTimer()
+		containerCount := min(i+1, maxContainers)
+
+		containerStr := strings.Repeat(container+",", containerCount)
+		containerStr = containerStr[:len(containerStr)-1]
+
+		manifest := strings.ReplaceAll(podManifest, "${containers}", containerStr)
+		pod := testingutils.Unstructured(manifest)
+		pod.SetNamespace(testingutils.FakeArgoCDNamespace)
+
+		syncCtx := newTestSyncCtx(nil, WithOperationSettings(false, true, false, false))
+		syncCtx.log = logr.Discard()
+		syncCtx.resources = groupResources(ReconciliationResult{
+			Live:   []*unstructured.Unstructured{nil, pod},
+			Target: []*unstructured.Unstructured{testingutils.NewService(), nil},
+		})
+
+		b.StartTimer()
+		syncCtx.Sync()
+	}
 }

--- a/pkg/utils/kube/kube_test.go
+++ b/pkg/utils/kube/kube_test.go
@@ -179,13 +179,11 @@ spec:
 }
 
 func TestGetResourceImages(t *testing.T) {
-	type testCase struct {
+	testCases := []struct {
 		manifest    []byte
 		expected    []string
 		description string
-	}
-
-	testCases := []testCase{
+	}{
 		{
 			manifest: []byte(`
 apiVersion: extensions/v1beta2

--- a/pkg/utils/kube/kube_test.go
+++ b/pkg/utils/kube/kube_test.go
@@ -239,7 +239,7 @@ spec:
 	require.Equal(t, expected, images)
 }
 
-func TestGetImages_NoImagesPresent(t *testing.T) {
+func TestGetImagesNoImagesPresent(t *testing.T) {
 	manifests := [][]byte{
 		[]byte(`
 apiVersion: v1

--- a/pkg/utils/kube/kube_test.go
+++ b/pkg/utils/kube/kube_test.go
@@ -208,7 +208,7 @@ spec:
 	require.NoError(t, err)
 
 	images := GetResourceImages(&deployment)
-	assert.Equal(t, expected, images)
+	require.Equal(t, expected, images)
 }
 
 func TestGetResourceImagesForPod(t *testing.T) {
@@ -236,7 +236,7 @@ spec:
 	require.NoError(t, err)
 
 	images := GetResourceImages(&pod)
-	assert.Equal(t, expected, images)
+	require.Equal(t, expected, images)
 }
 
 func TestSplitYAML_SingleObject(t *testing.T) {


### PR DESCRIPTION
Implementing the Gitops side of this issue: https://github.com/argoproj/argo-cd/issues/20896

Adds an api to `kube.go` to get the images from a resource. Adds those images to `ResourceSyncResult`. This API accounts for how different k8s resources define the images.

