### PR TITLE
feat: add health check support for ArgoCD Application

### DIFF
--- a/pkg/health/health.go
+++ b/pkg/health/health.go
@@ -120,6 +120,8 @@ func GetHealthCheckFunc(gvk schema.GroupVersionKind) func(obj *unstructured.Unst
 		switch gvk.Kind {
 		case "Workflow":
 			return getArgoWorkflowHealth
+		case "Application":
+			return getArgoApplicationHealth
 		}
 	case "apiregistration.k8s.io":
 		switch gvk.Kind {

--- a/pkg/health/health_argo.go
+++ b/pkg/health/health_argo.go
@@ -26,6 +26,15 @@ type argoWorkflow struct {
 	}
 }
 
+type argoApplication struct {
+	Status struct {
+		Health struct {
+			Status  HealthStatusCode
+			Message string
+		}
+	}
+}
+
 func getArgoWorkflowHealth(obj *unstructured.Unstructured) (*HealthStatus, error) {
 	var wf argoWorkflow
 	err := runtime.DefaultUnstructuredConverter.FromUnstructured(obj.Object, &wf)
@@ -41,4 +50,13 @@ func getArgoWorkflowHealth(obj *unstructured.Unstructured) (*HealthStatus, error
 		return &HealthStatus{Status: HealthStatusDegraded, Message: wf.Status.Message}, nil
 	}
 	return &HealthStatus{Status: HealthStatusUnknown, Message: wf.Status.Message}, nil
+}
+
+func getArgoApplicationHealth(obj *unstructured.Unstructured) (*HealthStatus, error) {
+	var app argoApplication
+	err := runtime.DefaultUnstructuredConverter.FromUnstructured(obj.Object, &app)
+	if err != nil {
+		return nil, err
+	}
+	return &HealthStatus{Status: app.Status.Health.Status, Message: app.Status.Health.Message}, nil
 }

--- a/pkg/health/health_test.go
+++ b/pkg/health/health_test.go
@@ -167,3 +167,8 @@ func TestGetArgoWorkflowHealth(t *testing.T) {
 	assert.Equal(t, "", health.Message)
 
 }
+
+func TestGetArgoApplicationHealth(t *testing.T) {
+	assertAppHealth(t, "./testdata/application-healthy.yaml", HealthStatusHealthy)
+	assertAppHealth(t, "./testdata/application-degraded.yaml", HealthStatusDegraded)
+}


### PR DESCRIPTION
When using a centralized ArgoCD instance in the control plane, it may sometimes be necessary to configure an ArgoCD Application as a hook, e.g. running an application as a post-sync hook, and specifying a destination cluster to execute jobs in a data plane cluster.

But right now the health check for this CRD is not supported in ArgoCD (or [Helm either](https://github.com/helm/helm/blob/main/pkg/kube/client.go#L750-L753)).. which makes it hard for the controller to determine whether to clean up the hook or not when using the delete policy HookSucceeded.