### PR TITLE
fix: run go mod tidy in ci workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,6 +22,7 @@ jobs:
       - uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed # v5.1.0
         with:
           go-version-file: go.mod
+      - run: go mod tidy
       - run: make test
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@971e284b6050e8a5849b72094c50ab08da042db8 # v6.1.1


### PR DESCRIPTION
Fixes issue that showed up in https://github.com/argoproj/gitops-engine/pull/650

[Error](https://github.com/argoproj/gitops-engine/actions/runs/12300709584/job/34329534904?pr=650#step:5:96)