### PR TITLE
fix(cluster): reduce lock contention on cluster initialization

### DIFF
--- a/pkg/cache/cluster.go
+++ b/pkg/cache/cluster.go
@@ -939,8 +939,9 @@ func (c *clusterCache) sync() error {
 					if un, ok := obj.(*unstructured.Unstructured); !ok {
 						return fmt.Errorf("object %s/%s has an unexpected type", un.GroupVersionKind().String(), un.GetName())
 					} else {
+						newRes := c.newResource(un)
 						lock.Lock()
-						c.setNode(c.newResource(un))
+						c.setNode(newRes)
 						lock.Unlock()
 					}
 					return nil


### PR DESCRIPTION
`c.newResource` calls `c.populateResourceInfoHandler` which, in Argo CD, may do nontrivial work: https://github.com/argoproj/argo-cd/blob/75def4f2df3e27892292b8020bfb9100a2784105/controller/cache/cache.go#L532-L560

As far as I can tell, `c.newResource` doesn't do any work which requires the lock.

This is the benchmark before/after:

```
Benchmark_sync-16    	     100	  10186413 ns/op
Benchmark_sync-16    	     212	   5531238 ns/op
```

Under the benchmark's conditions, cluster initialization is about twice as fast.