### PR TITLE
fix: Fix checking dryRun when using Server Side Apply

### DIFF
--- a/pkg/sync/sync_context.go
+++ b/pkg/sync/sync_context.go
@@ -1013,12 +1013,13 @@ func (sc *syncContext) ensureCRDReady(name string) error {
 	})
 }
 
-func (sc *syncContext) shouldUseServerSideApply(targetObj *unstructured.Unstructured) bool {
+func (sc *syncContext) shouldUseServerSideApply(targetObj *unstructured.Unstructured, dryRun bool) bool {
 	// if it is a dry run, disable server side apply, as the goal is to validate only the
 	// yaml correctness of the rendered manifests.
 	// running dry-run in server mode breaks the auto create namespace feature
 	// https://github.com/argoproj/argo-cd/issues/13874
-	if sc.dryRun {
+	if sc.dryRun || dryRun {
+		sc.log.Info("Dry run is true, disabling server-side apply")
 		return false
 	}
 
@@ -1026,7 +1027,6 @@ func (sc *syncContext) shouldUseServerSideApply(targetObj *unstructured.Unstruct
 	if resourceHasDisableSSAAnnotation {
 		return false
 	}
-
 	return sc.serverSideApply || resourceutil.HasAnnotationOption(targetObj, common.AnnotationSyncOptions, common.SyncOptionServerSideApply)
 }
 
@@ -1045,7 +1045,7 @@ func (sc *syncContext) applyObject(t *syncTask, dryRun, validate bool) (common.R
 	var message string
 	shouldReplace := sc.replace || resourceutil.HasAnnotationOption(t.targetObj, common.AnnotationSyncOptions, common.SyncOptionReplace)
 	force := sc.force || resourceutil.HasAnnotationOption(t.targetObj, common.AnnotationSyncOptions, common.SyncOptionForce)
-	serverSideApply := sc.shouldUseServerSideApply(t.targetObj)
+	serverSideApply := sc.shouldUseServerSideApply(t.targetObj, dryRun)
 	if shouldReplace {
 		if t.liveObj != nil {
 			// Avoid using `kubectl replace` for CRDs since 'replace' might recreate resource and so delete all CRD instances.

--- a/pkg/sync/sync_context.go
+++ b/pkg/sync/sync_context.go
@@ -1019,7 +1019,6 @@ func (sc *syncContext) shouldUseServerSideApply(targetObj *unstructured.Unstruct
 	// running dry-run in server mode breaks the auto create namespace feature
 	// https://github.com/argoproj/argo-cd/issues/13874
 	if sc.dryRun || dryRun {
-		sc.log.Info("Dry run is true, disabling server-side apply")
 		return false
 	}
 
@@ -1027,6 +1026,7 @@ func (sc *syncContext) shouldUseServerSideApply(targetObj *unstructured.Unstruct
 	if resourceHasDisableSSAAnnotation {
 		return false
 	}
+
 	return sc.serverSideApply || resourceutil.HasAnnotationOption(targetObj, common.AnnotationSyncOptions, common.SyncOptionServerSideApply)
 }
 


### PR DESCRIPTION
Fixes [ #21858](https://github.com/argoproj/argo-cd/issues/21858)

We did not properly check the correct dryRun flag before using ServerSideApply. We had previously checked only the sync context instead of passing the actual dryRun flag

During ArgoCD sync we always apply all resources in dry-run mode to make sure that all yamls are valid. In this case the
`sc.dryRun=False, dryRun=True`
Once we hit this case, we are essentially doing `kubectl apply --serverSide=true --dryRun=client` which leads to unintended results and actually wet applies resources: https://github.com/kubernetes/kubectl/blame/deef152435a8265c9cc91ff12e43c87132dbb0a8/pkg/cmd/apply/apply.go#L573

Following the bug reproduce steps:
Before fix:
Create application with resources across multiple sync waves (or hooks). I use a job in wave -1 in this case).
Sync it with server-side apply.
The sync will fail (as the job fails): however, the Deployment from a later wave was still synced.

After the fix:
Create application with resources across multiple sync waves (or hooks). I use a job in wave -1 in this case).
After performing sync with serverSideApply:
The sync fails(as the job fails). The job properly degrades, and the subsequent deployment (apply-to-sync-later) is still out of sync and doesn't apply.
![Screenshot 2025-03-12 at 2 29 24 PM](https://github.com/user-attachments/assets/960429b4-b9ad-4ebf-8ce5-deb1caf240ff)
