### PR TITLE
fix: go list is not working due to k8s.io/externaljwt dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -119,6 +119,7 @@ replace (
 	k8s.io/csi-translation-lib => k8s.io/csi-translation-lib v0.32.2
 	k8s.io/dynamic-resource-allocation => k8s.io/dynamic-resource-allocation v0.32.2
 	k8s.io/endpointslice => k8s.io/endpointslice v0.32.2
+	k8s.io/externaljwt => k8s.io/externaljwt v0.32.2
 	k8s.io/kms => k8s.io/kms v0.32.2
 	k8s.io/kube-aggregator => k8s.io/kube-aggregator v0.32.2
 	k8s.io/kube-controller-manager => k8s.io/kube-controller-manager v0.32.2


### PR DESCRIPTION
Getting error when executing `go list -modfile=~/go/src/github.com/argoproj/gitops-engine/go.mod -m -json -mod=mod all` locally it fails with 
<img width="1081" alt="Screenshot 2025-04-12 at 18 36 38" src="https://github.com/user-attachments/assets/2838177c-127c-476b-9104-6397d99ac40e" />

Goland executing it in order to load dependencies list