### PR TITLE
Add new API to propagate context and deprecate olds

### DIFF
--- a/pkg/cache/settings.go
+++ b/pkg/cache/settings.go
@@ -30,7 +30,10 @@ func (f *noopSettings) IsExcludedResource(_, _, _ string) bool {
 // Settings caching customizations
 type Settings struct {
 	// ResourceHealthOverride contains health assessment overrides
+	// Deprecated: use ResourceHealthOverrideContext insttead.
 	ResourceHealthOverride health.HealthOverride
+	// ResourceHealthOverrideContext contains health assessment overrides
+	ResourceHealthOverrideContext health.HealthOverrideContext
 	// ResourcesFilter holds filter that excludes resources
 	ResourcesFilter kube.ResourceFilter
 }
@@ -54,7 +57,7 @@ func SetPopulateResourceInfoHandler(handler OnPopulateResourceInfoHandler) Updat
 // SetSettings updates caching settings
 func SetSettings(settings Settings) UpdateSettingsFunc {
 	return func(cache *clusterCache) {
-		cache.settings = Settings{settings.ResourceHealthOverride, settings.ResourcesFilter}
+		cache.settings = Settings{settings.ResourceHealthOverride, settings.ResourceHealthOverrideContext, settings.ResourcesFilter}
 	}
 }
 

--- a/pkg/diff/diff.go
+++ b/pkg/diff/diff.go
@@ -61,9 +61,15 @@ func (n *noopNormalizer) Normalize(_ *unstructured.Unstructured) error {
 	return nil
 }
 
+func (n *noopNormalizer) NormalizeContext(_ context.Context, _ *unstructured.Unstructured) error {
+	return nil
+}
+
 // Normalizer updates resource before comparing it
 type Normalizer interface {
+	// Deprecated: use NormalizeContext instead
 	Normalize(un *unstructured.Unstructured) error
+	NormalizeContext(ctx context.Context, un *unstructured.Unstructured) error
 }
 
 // GetNoopNormalizer returns normalizer that does not apply any resource modifications

--- a/pkg/health/health_test.go
+++ b/pkg/health/health_test.go
@@ -5,6 +5,7 @@ Package provides functionality that allows assessing the health state of a Kuber
 package health
 
 import (
+	"context"
 	"os"
 	"testing"
 
@@ -28,7 +29,7 @@ func getHealthStatus(t *testing.T, yamlPath string) *HealthStatus {
 	var obj unstructured.Unstructured
 	err = yaml.Unmarshal(yamlBytes, &obj)
 	require.NoError(t, err)
-	health, err := GetResourceHealth(&obj, nil)
+	health, err := GetResourceHealthContext(context.Background(), &obj, nil)
 	require.NoError(t, err)
 	return health
 }

--- a/pkg/utils/kube/kubetest/mock.go
+++ b/pkg/utils/kube/kubetest/mock.go
@@ -96,6 +96,9 @@ func (k *MockKubectlCmd) LoadOpenAPISchema(_ *rest.Config) (openapi.Resources, *
 func (k *MockKubectlCmd) SetOnKubectlRun(_ kube.OnKubectlRunFunc) {
 }
 
+func (k *MockKubectlCmd) SetOnKubectlRunContext(_ kube.OnKubectlRunFuncContext) {
+}
+
 func (k *MockKubectlCmd) ManageResources(_ *rest.Config, _ openapi.Resources) (kube.ResourceOperations, func(), error) {
 	return &MockResourceOps{}, func() {
 	}, nil

--- a/pkg/utils/kube/resource_ops.go
+++ b/pkg/utils/kube/resource_ops.go
@@ -50,7 +50,7 @@ type kubectlResourceOperations struct {
 	config        *rest.Config
 	log           logr.Logger
 	tracer        tracing.Tracer
-	onKubectlRun  OnKubectlRunFunc
+	onKubectlRun  OnKubectlRunFuncContext
 	fact          cmdutil.Factory
 	openAPISchema openapi.Resources
 }
@@ -60,7 +60,7 @@ type kubectlServerSideDiffDryRunApplier struct {
 	config        *rest.Config
 	log           logr.Logger
 	tracer        tracing.Tracer
-	onKubectlRun  OnKubectlRunFunc
+	onKubectlRun  OnKubectlRunFuncContext
 	fact          cmdutil.Factory
 	openAPISchema openapi.Resources
 }
@@ -193,7 +193,7 @@ func (k *kubectlServerSideDiffDryRunApplier) runResourceCommand(obj *unstructure
 // See: https://github.com/kubernetes/kubernetes/issues/66353
 // `auth reconcile` will delete and recreate the resource if necessary
 func (k *kubectlResourceOperations) rbacReconcile(ctx context.Context, obj *unstructured.Unstructured, fileName string, dryRunStrategy cmdutil.DryRunStrategy) (string, error) {
-	cleanup, err := processKubectlRun(k.onKubectlRun, "auth")
+	cleanup, err := processKubectlRun(ctx, k.onKubectlRun, "auth")
 	if err != nil {
 		return "", fmt.Errorf("error processing kubectl run auth: %w", err)
 	}
@@ -227,7 +227,7 @@ func (k *kubectlResourceOperations) ReplaceResource(ctx context.Context, obj *un
 	defer span.Finish()
 	k.log.Info(fmt.Sprintf("Replacing resource %s/%s in cluster: %s, namespace: %s", obj.GetKind(), obj.GetName(), k.config.Host, obj.GetNamespace()))
 	return k.runResourceCommand(ctx, obj, dryRunStrategy, func(ioStreams genericclioptions.IOStreams, fileName string) error {
-		cleanup, err := processKubectlRun(k.onKubectlRun, "replace")
+		cleanup, err := processKubectlRun(ctx, k.onKubectlRun, "replace")
 		if err != nil {
 			return err
 		}
@@ -248,7 +248,7 @@ func (k *kubectlResourceOperations) CreateResource(ctx context.Context, obj *uns
 	span.SetBaggageItem("name", obj.GetName())
 	defer span.Finish()
 	return k.runResourceCommand(ctx, obj, dryRunStrategy, func(ioStreams genericclioptions.IOStreams, fileName string) error {
-		cleanup, err := processKubectlRun(k.onKubectlRun, "create")
+		cleanup, err := processKubectlRun(ctx, k.onKubectlRun, "create")
 		if err != nil {
 			return err
 		}
@@ -301,7 +301,7 @@ func (k *kubectlResourceOperations) UpdateResource(ctx context.Context, obj *uns
 }
 
 // ApplyResource performs an apply of a unstructured resource
-func (k *kubectlServerSideDiffDryRunApplier) ApplyResource(_ context.Context, obj *unstructured.Unstructured, dryRunStrategy cmdutil.DryRunStrategy, force bool, validate bool, serverSideApply bool, manager string) (string, error) {
+func (k *kubectlServerSideDiffDryRunApplier) ApplyResource(ctx context.Context, obj *unstructured.Unstructured, dryRunStrategy cmdutil.DryRunStrategy, force bool, validate bool, serverSideApply bool, manager string) (string, error) {
 	span := k.tracer.StartSpan("ApplyResource")
 	span.SetBaggageItem("kind", obj.GetKind())
 	span.SetBaggageItem("name", obj.GetName())
@@ -312,7 +312,7 @@ func (k *kubectlServerSideDiffDryRunApplier) ApplyResource(_ context.Context, ob
 		"serverSideApply", serverSideApply).Info(fmt.Sprintf("Running server-side diff. Dry run applying resource %s/%s in cluster: %s, namespace: %s", obj.GetKind(), obj.GetName(), k.config.Host, obj.GetNamespace()))
 
 	return k.runResourceCommand(obj, func(ioStreams genericclioptions.IOStreams, fileName string) error {
-		cleanup, err := processKubectlRun(k.onKubectlRun, "apply")
+		cleanup, err := processKubectlRun(ctx, k.onKubectlRun, "apply")
 		if err != nil {
 			return err
 		}
@@ -343,7 +343,7 @@ func (k *kubectlResourceOperations) ApplyResource(ctx context.Context, obj *unst
 		"serverSideDiff", true).Info(fmt.Sprintf("Applying resource %s/%s in cluster: %s, namespace: %s", obj.GetKind(), obj.GetName(), k.config.Host, obj.GetNamespace()))
 
 	return k.runResourceCommand(ctx, obj, dryRunStrategy, func(ioStreams genericclioptions.IOStreams, fileName string) error {
-		cleanup, err := processKubectlRun(k.onKubectlRun, "apply")
+		cleanup, err := processKubectlRun(ctx, k.onKubectlRun, "apply")
 		if err != nil {
 			return err
 		}
@@ -616,9 +616,9 @@ func (k *kubectlResourceOperations) authReconcile(ctx context.Context, obj *unst
 	return strings.Join(out, ". "), nil
 }
 
-func processKubectlRun(onKubectlRun OnKubectlRunFunc, cmd string) (CleanupFunc, error) {
+func processKubectlRun(ctx context.Context, onKubectlRun OnKubectlRunFuncContext, cmd string) (CleanupFunc, error) {
 	if onKubectlRun != nil {
-		return onKubectlRun(cmd)
+		return onKubectlRun(ctx, cmd)
 	}
 	return func() {}, nil
 }


### PR DESCRIPTION
This is part of https://github.com/argoproj/argo-cd/pull/21963
I added new API to propagate context for each function and deprecate olds that doesn't have cotnext.