### PR TITLE
chore: Use watch APIs to list k8s resources

### DIFF
--- a/pkg/cache/cluster.go
+++ b/pkg/cache/cluster.go
@@ -613,7 +613,7 @@ func (c *clusterCache) listResources(ctx context.Context, resClient dynamic.Reso
 		if success {
 			listOpts = watchListOpts
 			c.listResourcesUsingWatchAPI.Add(1)
-			c.log.Info("Would use watch list options to list resources.")
+			c.log.Info("Would try to use watch list options to list resources.")
 		} else {
 			listOpts = opts
 			c.listResourcesUsingRegularAPI.Add(1)

--- a/pkg/cache/cluster_test.go
+++ b/pkg/cache/cluster_test.go
@@ -234,8 +234,8 @@ func TestEnsureSyncedAndUsingWatchAPIs(t *testing.T) {
 	}
 	assert.ElementsMatch(t, []string{"helm-guestbook1", "helm-guestbook2"}, names)
 
-	assert.Greater(t, cluster.listResourcesUsingWatchAPI.Load(), int32(0))
-	assert.Equal(t, cluster.listResourcesUsingRegularAPI.Load(), int32(0))
+	assert.Positive(t, cluster.listResourcesUsingWatchAPI.Load())
+	assert.Equal(t, int32(0), cluster.listResourcesUsingRegularAPI.Load())
 }
 
 func TestStatefulSetOwnershipInferred(t *testing.T) {


### PR DESCRIPTION
Use watch APIs to list resources instead of paginated regular APIs.