### PR TITLE
Fix generating incorrect names for Jobs when `generateName` is used

### DIFF
--- a/pkg/sync/sync_context.go
+++ b/pkg/sync/sync_context.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"unicode"
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
@@ -754,7 +755,9 @@ func (sc *syncContext) getSyncTasks() (_ syncTasks, successful bool) {
 				if targetObj.GetName() == "" {
 					var syncRevision string
 					if len(sc.revision) >= 8 {
-						syncRevision = strings.Trim(sc.revision[0:7], ".")
+						syncRevision = strings.TrimFunc(sc.revision[0:7], func(r rune) bool {
+							return !unicode.IsLetter(r) && !unicode.IsNumber(r) && r != '-'
+						})
 					} else {
 						syncRevision = sc.revision
 					}

--- a/pkg/sync/sync_context_test.go
+++ b/pkg/sync/sync_context_test.go
@@ -993,8 +993,8 @@ func TestUnnamedHooksGetUniqueNames(t *testing.T) {
 		assert.Contains(t, tasks[0].name(), "f.ooba-presync-")
 		assert.Contains(t, tasks[1].name(), "f.ooba-postsync-")
 		assert.Equal(t, "", pod.GetName())
-    assert.Empty(t, validation.IsDNS1123Subdomain(tasks[0].name()))
-    assert.Empty(t, validation.IsDNS1123Subdomain(tasks[1].name()))
+		assert.Empty(t, validation.IsDNS1123Subdomain(tasks[0].name()))
+		assert.Empty(t, validation.IsDNS1123Subdomain(tasks[1].name()))
 	})
 }
 


### PR DESCRIPTION
Discovered a case when processing of `generateName` produces incorrect results.

For example if you have revision `1.1515.1` it's being cut a `1.1515.` and combined with suffix that starts with `-` character produces name that does not comply with RFC1123. 