### PR TITLE
chore(deps): bump golangci-lint

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,9 +20,9 @@ jobs:
       - run: go mod tidy
       - run: make test
       - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@971e284b6050e8a5849b72094c50ab08da042db8 # v6.1.1
+        uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8.0.0
         with:
-          version:  v1.63.4
+          version:  v2.1.6
           args: --verbose
       - uses: codecov/codecov-action@a2f73fb6db51fcd2e0aa085dfb36dea90c5e3689 # v5.0.2
         with:

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -97,7 +97,6 @@ linters:
       disable:
         - go-require
   exclusions:
-    generated: lax
     presets:
       - comments
       - common-false-positives
@@ -121,7 +120,6 @@ formatters:
       local-prefixes:
         - github.com/argoproj/gitops-engine
   exclusions:
-    generated: lax
     paths:
       - pkg/diff/internal/fieldmanager/borrowed_.*\.go$
       - internal/kubernetes_vendor

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,124 +1,130 @@
-issues:
-  exclude-dirs:
-    - internal/kubernetes_vendor
-  exclude-files:
-    - "pkg/diff/internal/fieldmanager/borrowed_.*\\.go$"
-  max-issues-per-linter: 0
-  max-same-issues: 0
+version: "2"
 linters:
   enable:
-    - errcheck
     - errorlint
     - gocritic
-    - gofumpt
-    - goimports
     - gomodguard
-    - gosimple
-    - govet
     - importas
-    - ineffassign
     - misspell
-    # Disabled because of https://github.com/argoproj/argo-cd/issues/21705
-    # - nolintlint
     - perfsprint
     - revive
-    - staticcheck
     - testifylint
     - thelper
     - unparam
-    - unused
     - usestdlibvars
     - whitespace
-linters-settings:
-  gocritic:
-    disabled-checks:
-      - appendAssign
-      - assignOp # Keep it disabled for readability
-      - exitAfterDefer
-      - typeSwitchVar
-  goimports:
-    local-prefixes: github.com/argoproj/gitops-engine
-  importas:
-    alias:
-      - alias: appsv1
-        pkg: k8s.io/api/apps/v1
-      - alias: corev1
-        pkg: k8s.io/api/core/v1
-      - alias: apierrors
-        pkg: k8s.io/apimachinery/pkg/api/errors
-      - alias: apiextensionsv1
-        pkg: k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1
-      - alias: metav1
-        pkg: k8s.io/apimachinery/pkg/apis/meta/v1
-      - alias: testingutils
-        pkg: github.com/argoproj/gitops-engine/pkg/utils/testing
-  perfsprint:
-    # Optimizes even if it requires an int or uint type cast.
-    int-conversion: true
-    # Optimizes into `err.Error()` even if it is only equivalent for non-nil errors.
-    err-error: true
-    # Optimizes `fmt.Errorf`.
-    errorf: true
-    # Optimizes `fmt.Sprintf` with only one argument.
-    sprintf1: true
-    # Optimizes into strings concatenation.
-    strconcat: true
-  revive:
-    # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md
-    rules:
-      - name: bool-literal-in-expr
-      - name: blank-imports
-        disabled: true
-      - name: context-as-argument
-        arguments:
-          - allowTypesBefore: '*testing.T,testing.TB'
-      - name: context-keys-type
-        disabled: true
-      - name: dot-imports
-      - name: duplicated-imports
-      - name: early-return
-        arguments:
-          - 'preserveScope'
-      - name: empty-block
-        disabled: true
-      - name: error-naming
-        disabled: true
-      - name: error-return
-      - name: error-strings
-        disabled: true
-      - name: errorf
-      - name: identical-branches
-      - name: if-return
-      - name: increment-decrement
-      - name: indent-error-flow
-        arguments:
-          - 'preserveScope'
-      - name: modifies-parameter
-      - name: optimize-operands-order
-      - name: range
-      - name: receiver-naming
-      - name: redefines-builtin-id
-        disabled: true
-      - name: redundant-import-alias
-      - name: superfluous-else
-        arguments:
-          - 'preserveScope'
-      - name: time-equal
-      - name: time-naming
-        disabled: true
-      - name: unexported-return
-        disabled: true
-      - name: unnecessary-stmt
-      - name: unreachable-code
-      - name: unused-parameter
-      - name: use-any
-      - name: useless-break
-      - name: var-declaration
-      - name: var-naming
-        disabled: true
-  testifylint:
-    enable-all: true
-    disable:
-      - go-require
-run:
-  timeout: 5m
+  settings:
+    gocritic:
+      disabled-checks:
+        - appendAssign
+        - assignOp
+        - exitAfterDefer
+        - typeSwitchVar
+    importas:
+      alias:
+        - pkg: k8s.io/api/apps/v1
+          alias: appsv1
+        - pkg: k8s.io/api/core/v1
+          alias: corev1
+        - pkg: k8s.io/apimachinery/pkg/api/errors
+          alias: apierrors
+        - pkg: k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1
+          alias: apiextensionsv1
+        - pkg: k8s.io/apimachinery/pkg/apis/meta/v1
+          alias: metav1
+        - pkg: github.com/argoproj/gitops-engine/pkg/utils/testing
+          alias: testingutils
+    perfsprint:
+      int-conversion: true
+      err-error: true
+      errorf: true
+      sprintf1: true
+      strconcat: true
+    revive:
+      rules:
+        - name: bool-literal-in-expr
+        - name: blank-imports
+          disabled: true
+        - name: context-as-argument
+          arguments:
+            - allowTypesBefore: '*testing.T,testing.TB'
+        - name: context-keys-type
+          disabled: true
+        - name: dot-imports
+        - name: duplicated-imports
+        - name: early-return
+          arguments:
+            - preserveScope
+        - name: empty-block
+          disabled: true
+        - name: error-naming
+          disabled: true
+        - name: error-return
+        - name: error-strings
+          disabled: true
+        - name: errorf
+        - name: identical-branches
+        - name: if-return
+        - name: increment-decrement
+        - name: indent-error-flow
+          arguments:
+            - preserveScope
+        - name: modifies-parameter
+        - name: optimize-operands-order
+        - name: range
+        - name: receiver-naming
+        - name: redefines-builtin-id
+          disabled: true
+        - name: redundant-import-alias
+        - name: superfluous-else
+          arguments:
+            - preserveScope
+        - name: time-equal
+        - name: time-naming
+          disabled: true
+        - name: unexported-return
+          disabled: true
+        - name: unnecessary-stmt
+        - name: unreachable-code
+        - name: unused-parameter
+        - name: use-any
+        - name: useless-break
+        - name: var-declaration
+        - name: var-naming
+          disabled: true
+    testifylint:
+      enable-all: true
+      disable:
+        - go-require
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - pkg/diff/internal/fieldmanager/borrowed_.*\.go$
+      - internal/kubernetes_vendor
+      - third_party$
+      - builtin$
+      - examples$
+issues:
+  max-issues-per-linter: 0
+  max-same-issues: 0
+formatters:
+  enable:
+    - gofumpt
+    - goimports
+  settings:
+    goimports:
+      local-prefixes:
+        - github.com/argoproj/gitops-engine
+  exclusions:
+    generated: lax
+    paths:
+      - pkg/diff/internal/fieldmanager/borrowed_.*\.go$
+      - internal/kubernetes_vendor
+      - third_party$
+      - builtin$
+      - examples$

--- a/agent/main.go
+++ b/agent/main.go
@@ -54,7 +54,7 @@ type settings struct {
 
 func (s *settings) getGCMark(key kube.ResourceKey) string {
 	h := sha256.New()
-	_, _ = h.Write([]byte(fmt.Sprintf("%s/%s", s.repoPath, strings.Join(s.paths, ","))))
+	_, _ = fmt.Fprintf(h, "%s/%s", s.repoPath, strings.Join(s.paths, ","))
 	_, _ = h.Write([]byte(strings.Join([]string{key.Group, key.Kind, key.Name}, "/")))
 	return "sha256." + base64.RawURLEncoding.EncodeToString(h.Sum(nil))
 }

--- a/pkg/cache/cluster.go
+++ b/pkg/cache/cluster.go
@@ -654,7 +654,7 @@ func (c *clusterCache) watchEvents(ctx context.Context, api kube.APIResourceInfo
 	kube.RetryUntilSucceed(ctx, watchResourcesRetryTimeout, fmt.Sprintf("watch %s on %s", api.GroupKind, c.config.Host), c.log, func() (err error) {
 		defer func() {
 			if r := recover(); r != nil {
-				err = fmt.Errorf("Recovered from panic: %+v\n%s", r, debug.Stack())
+				err = fmt.Errorf("recovered from panic: %+v\n%s", r, debug.Stack())
 			}
 		}()
 
@@ -699,20 +699,20 @@ func (c *clusterCache) watchEvents(ctx context.Context, api kube.APIResourceInfo
 
 			// re-synchronize API state and restart watch periodically
 			case <-watchResyncTimeoutCh:
-				return fmt.Errorf("Resyncing %s on %s due to timeout", api.GroupKind, c.config.Host)
+				return fmt.Errorf("resyncing %s on %s due to timeout", api.GroupKind, c.config.Host)
 
 			// re-synchronize API state and restart watch if retry watcher failed to continue watching using provided resource version
 			case <-w.Done():
-				return fmt.Errorf("Watch %s on %s has closed", api.GroupKind, c.config.Host)
+				return fmt.Errorf("watch %s on %s has closed", api.GroupKind, c.config.Host)
 
 			case event, ok := <-w.ResultChan():
 				if !ok {
-					return fmt.Errorf("Watch %s on %s has closed", api.GroupKind, c.config.Host)
+					return fmt.Errorf("watch %s on %s has closed", api.GroupKind, c.config.Host)
 				}
 
 				obj, ok := event.Object.(*unstructured.Unstructured)
 				if !ok {
-					return fmt.Errorf("Failed to convert to *unstructured.Unstructured: %v", event.Object)
+					return fmt.Errorf("failed to convert to *unstructured.Unstructured: %v", event.Object)
 				}
 
 				c.recordEvent(event.Type, obj)
@@ -1217,9 +1217,9 @@ func (c *clusterCache) GetManagedLiveObjs(targetObjs []*unstructured.Unstructure
 	for _, o := range targetObjs {
 		if len(c.namespaces) > 0 {
 			if o.GetNamespace() == "" && !c.clusterResources {
-				return nil, fmt.Errorf("Cluster level %s %q can not be managed when in namespaced mode", o.GetKind(), o.GetName())
+				return nil, fmt.Errorf("cluster level %s %q can not be managed when in namespaced mode", o.GetKind(), o.GetName())
 			} else if o.GetNamespace() != "" && !c.managesNamespace(o.GetNamespace()) {
-				return nil, fmt.Errorf("Namespace %q for %s %q is not managed", o.GetNamespace(), o.GetKind(), o.GetName())
+				return nil, fmt.Errorf("namespace %q for %s %q is not managed", o.GetNamespace(), o.GetKind(), o.GetName())
 			}
 		}
 	}

--- a/pkg/cache/cluster_test.go
+++ b/pkg/cache/cluster_test.go
@@ -441,7 +441,7 @@ metadata:
 		return len(r.OwnerRefs) == 0
 	})
 	assert.Nil(t, managedObjs)
-	assert.EqualError(t, err, "Cluster level Deployment \"helm-guestbook\" can not be managed when in namespaced mode")
+	assert.EqualError(t, err, "cluster level Deployment \"helm-guestbook\" can not be managed when in namespaced mode")
 }
 
 func TestGetManagedLiveObjsNamespacedModeClusterLevelResource_ClusterResourceEnabled(t *testing.T) {
@@ -482,7 +482,7 @@ metadata:
 	_, err = cluster.GetManagedLiveObjs([]*unstructured.Unstructured{otherNamespaceRes}, func(r *Resource) bool {
 		return len(r.OwnerRefs) == 0
 	})
-	assert.EqualError(t, err, "Namespace \"some-other-namespace\" for Deployment \"helm-guestbook\" is not managed")
+	assert.EqualError(t, err, "namespace \"some-other-namespace\" for Deployment \"helm-guestbook\" is not managed")
 }
 
 func TestGetManagedLiveObjsAllNamespaces(t *testing.T) {
@@ -564,7 +564,7 @@ metadata:
 		return len(r.OwnerRefs) == 0
 	})
 	assert.Nil(t, managedObjs)
-	assert.EqualError(t, err, "Namespace \"production\" for Deployment \"helm-guestbook\" is not managed")
+	assert.EqualError(t, err, "namespace \"production\" for Deployment \"helm-guestbook\" is not managed")
 }
 
 func TestGetManagedLiveObjsFailedConversion(t *testing.T) {

--- a/pkg/cache/resource.go
+++ b/pkg/cache/resource.go
@@ -118,10 +118,11 @@ func (r *Resource) iterateChildrenV2(graph map[kube.ResourceKey]map[types.UID]*R
 	for _, c := range children {
 		childKey := c.ResourceKey()
 		child := ns[childKey]
-		if visited[childKey] == 1 {
+		switch visited[childKey] {
+		case 1:
 			// Since we encountered a node that we're currently processing, we know we have a circular dependency.
 			_ = action(fmt.Errorf("circular dependency detected. %s is child and parent of %s", childKey.String(), key.String()), child, ns)
-		} else if visited[childKey] == 0 {
+		case 0:
 			if action(nil, child, ns) {
 				child.iterateChildrenV2(graph, ns, visited, action)
 			}

--- a/pkg/diff/diff_test.go
+++ b/pkg/diff/diff_test.go
@@ -275,7 +275,7 @@ func TestDiffArrayModification(t *testing.T) {
 func TestThreeWayDiff(t *testing.T) {
 	// 1. get config and live to be the same. Both have a foo annotation.
 	configDep := newDeployment()
-	configDep.ObjectMeta.Namespace = ""
+	configDep.Namespace = ""
 	configDep.Annotations = map[string]string{
 		"foo": "bar",
 	}
@@ -540,7 +540,7 @@ func TestRemoveNamespaceAnnotation(t *testing.T) {
 			"namespace": "default",
 		},
 	}})
-	assert.Equal(t, "", obj.GetNamespace())
+	assert.Empty(t, obj.GetNamespace())
 
 	obj = removeNamespaceAnnotation(&unstructured.Unstructured{Object: map[string]any{
 		"metadata": map[string]any{
@@ -549,7 +549,7 @@ func TestRemoveNamespaceAnnotation(t *testing.T) {
 			"annotations": make(map[string]any),
 		},
 	}})
-	assert.Equal(t, "", obj.GetNamespace())
+	assert.Empty(t, obj.GetNamespace())
 	assert.Nil(t, obj.GetAnnotations())
 
 	obj = removeNamespaceAnnotation(&unstructured.Unstructured{Object: map[string]any{
@@ -559,7 +559,7 @@ func TestRemoveNamespaceAnnotation(t *testing.T) {
 			"annotations": "wrong value",
 		},
 	}})
-	assert.Equal(t, "", obj.GetNamespace())
+	assert.Empty(t, obj.GetNamespace())
 	val, _, _ := unstructured.NestedString(obj.Object, "metadata", "annotations")
 	assert.Equal(t, "wrong value", val)
 }

--- a/pkg/health/health_test.go
+++ b/pkg/health/health_test.go
@@ -170,5 +170,5 @@ func TestGetArgoWorkflowHealth(t *testing.T) {
 	health, err = getArgoWorkflowHealth(&sampleWorkflow)
 	require.NoError(t, err)
 	assert.Equal(t, HealthStatusProgressing, health.Status)
-	assert.Equal(t, "", health.Message)
+	assert.Empty(t, health.Message)
 }

--- a/pkg/sync/sync_context.go
+++ b/pkg/sync/sync_context.go
@@ -960,10 +960,10 @@ func (sc *syncContext) autoCreateNamespace(tasks syncTasks) syncTasks {
 			case apierrors.IsNotFound(err):
 				tasks = sc.appendNsTask(tasks, &syncTask{phase: common.SyncPhasePreSync, targetObj: managedNs, liveObj: nil}, managedNs, nil)
 			default:
-				tasks = sc.appendFailedNsTask(tasks, managedNs, fmt.Errorf("Namespace auto creation failed: %w", err))
+				tasks = sc.appendFailedNsTask(tasks, managedNs, fmt.Errorf("namespace auto creation failed: %w", err))
 			}
 		} else {
-			sc.setOperationPhase(common.OperationFailed, fmt.Sprintf("Namespace auto creation failed: %s", err))
+			sc.setOperationPhase(common.OperationFailed, fmt.Sprintf("namespace auto creation failed: %s", err))
 		}
 	}
 	return tasks

--- a/pkg/sync/sync_context_test.go
+++ b/pkg/sync/sync_context_test.go
@@ -137,9 +137,9 @@ func TestSyncCreateInSortedOrder(t *testing.T) {
 		switch result.ResourceKey.Kind {
 		case "Pod":
 			assert.Equal(t, synccommon.ResultCodeSynced, result.Status)
-			assert.Equal(t, "", result.Message)
+			assert.Empty(t, result.Message)
 		case "Service":
-			assert.Equal(t, "", result.Message)
+			assert.Empty(t, result.Message)
 		default:
 			t.Error("Resource isn't a pod or a service")
 		}
@@ -271,7 +271,7 @@ func TestSyncSuccessfully(t *testing.T) {
 			assert.Equal(t, "pruned", result.Message)
 		case "Service":
 			assert.Equal(t, synccommon.ResultCodeSynced, result.Status)
-			assert.Equal(t, "", result.Message)
+			assert.Empty(t, result.Message)
 		default:
 			t.Error("Resource isn't a pod or a service")
 		}
@@ -959,7 +959,7 @@ func TestUnnamedHooksGetUniqueNames(t *testing.T) {
 		assert.Len(t, tasks, 2)
 		assert.Contains(t, tasks[0].name(), "foobarb-presync-")
 		assert.Contains(t, tasks[1].name(), "foobarb-postsync-")
-		assert.Equal(t, "", pod.GetName())
+		assert.Empty(t, pod.GetName())
 	})
 
 	t.Run("Short revision", func(t *testing.T) {
@@ -975,7 +975,7 @@ func TestUnnamedHooksGetUniqueNames(t *testing.T) {
 		assert.Len(t, tasks, 2)
 		assert.Contains(t, tasks[0].name(), "foobar-presync-")
 		assert.Contains(t, tasks[1].name(), "foobar-postsync-")
-		assert.Equal(t, "", pod.GetName())
+		assert.Empty(t, pod.GetName())
 	})
 }
 
@@ -993,8 +993,8 @@ func TestManagedResourceAreNotNamed(t *testing.T) {
 
 	assert.True(t, successful)
 	assert.Len(t, tasks, 1)
-	assert.Equal(t, "", tasks[0].name())
-	assert.Equal(t, "", pod.GetName())
+	assert.Empty(t, tasks[0].name())
+	assert.Empty(t, pod.GetName())
 }
 
 func TestDeDupingTasks(t *testing.T) {
@@ -1026,7 +1026,7 @@ func TestObjectsGetANamespace(t *testing.T) {
 	assert.True(t, successful)
 	assert.Len(t, tasks, 1)
 	assert.Equal(t, testingutils.FakeArgoCDNamespace, tasks[0].namespace())
-	assert.Equal(t, "", pod.GetNamespace())
+	assert.Empty(t, pod.GetNamespace())
 }
 
 func TestNamespaceAutoCreation(t *testing.T) {

--- a/pkg/sync/sync_task_test.go
+++ b/pkg/sync/sync_task_test.go
@@ -36,7 +36,7 @@ func Test_syncTask_hookType(t *testing.T) {
 				liveObj: tt.fields.liveObj,
 			}
 			hookType := task.hookType()
-			assert.EqualValues(t, tt.want, hookType)
+			assert.Equal(t, tt.want, hookType)
 		})
 	}
 }

--- a/pkg/utils/json/json.go
+++ b/pkg/utils/json/json.go
@@ -7,16 +7,14 @@ func removeFields(config, live any) any {
 		l, ok := live.(map[string]any)
 		if ok {
 			return RemoveMapFields(c, l)
-		} else {
-			return live
 		}
+		return live
 	case []any:
 		l, ok := live.([]any)
 		if ok {
 			return RemoveListFields(c, l)
-		} else {
-			return live
 		}
+		return live
 	default:
 		return live
 	}

--- a/pkg/utils/kube/kube.go
+++ b/pkg/utils/kube/kube.go
@@ -245,10 +245,10 @@ func NewKubeConfig(restConfig *rest.Config, namespace string) *clientcmdapi.Conf
 		Clusters: map[string]*clientcmdapi.Cluster{
 			restConfig.Host: {
 				Server:                   restConfig.Host,
-				TLSServerName:            restConfig.TLSClientConfig.ServerName,
-				InsecureSkipTLSVerify:    restConfig.TLSClientConfig.Insecure,
-				CertificateAuthority:     restConfig.TLSClientConfig.CAFile,
-				CertificateAuthorityData: restConfig.TLSClientConfig.CAData,
+				TLSServerName:            restConfig.ServerName,
+				InsecureSkipTLSVerify:    restConfig.Insecure,
+				CertificateAuthority:     restConfig.CAFile,
+				CertificateAuthorityData: restConfig.CAData,
 				ProxyURL:                 proxyUrl,
 			},
 		},
@@ -263,20 +263,20 @@ func NewKubeConfig(restConfig *rest.Config, namespace string) *clientcmdapi.Conf
 func newAuthInfo(restConfig *rest.Config) *clientcmdapi.AuthInfo {
 	authInfo := clientcmdapi.AuthInfo{}
 	haveCredentials := false
-	if restConfig.TLSClientConfig.CertFile != "" {
-		authInfo.ClientCertificate = restConfig.TLSClientConfig.CertFile
+	if restConfig.CertFile != "" {
+		authInfo.ClientCertificate = restConfig.CertFile
 		haveCredentials = true
 	}
-	if len(restConfig.TLSClientConfig.CertData) > 0 {
-		authInfo.ClientCertificateData = restConfig.TLSClientConfig.CertData
+	if len(restConfig.CertData) > 0 {
+		authInfo.ClientCertificateData = restConfig.CertData
 		haveCredentials = true
 	}
-	if restConfig.TLSClientConfig.KeyFile != "" {
-		authInfo.ClientKey = restConfig.TLSClientConfig.KeyFile
+	if restConfig.KeyFile != "" {
+		authInfo.ClientKey = restConfig.KeyFile
 		haveCredentials = true
 	}
-	if len(restConfig.TLSClientConfig.KeyData) > 0 {
-		authInfo.ClientKeyData = restConfig.TLSClientConfig.KeyData
+	if len(restConfig.KeyData) > 0 {
+		authInfo.ClientKeyData = restConfig.KeyData
 		haveCredentials = true
 	}
 	if restConfig.Username != "" {

--- a/pkg/utils/kube/kube_test.go
+++ b/pkg/utils/kube/kube_test.go
@@ -54,7 +54,7 @@ func TestUnsetLabels(t *testing.T) {
 		var dep extv1beta1.Deployment
 		err = json.Unmarshal(manifestBytes, &dep)
 		require.NoError(t, err)
-		assert.Empty(t, dep.ObjectMeta.Labels)
+		assert.Empty(t, dep.Labels)
 	}
 }
 

--- a/pkg/utils/kube/resource_ops.go
+++ b/pkg/utils/kube/resource_ops.go
@@ -95,13 +95,13 @@ func createManifestFile(obj *unstructured.Unstructured, log logr.Logger) (*os.Fi
 	}
 	manifestFile, err := os.CreateTemp(io.TempDir, "")
 	if err != nil {
-		return nil, fmt.Errorf("Failed to generate temp file for manifest: %w", err)
+		return nil, fmt.Errorf("failed to generate temp file for manifest: %w", err)
 	}
 	if _, err = manifestFile.Write(manifestBytes); err != nil {
-		return nil, fmt.Errorf("Failed to write manifest: %w", err)
+		return nil, fmt.Errorf("failed to write manifest: %w", err)
 	}
 	if err = manifestFile.Close(); err != nil {
-		return nil, fmt.Errorf("Failed to close manifest: %w", err)
+		return nil, fmt.Errorf("failed to close manifest: %w", err)
 	}
 
 	err = maybeLogManifest(manifestBytes, log)
@@ -173,7 +173,7 @@ func (k *kubectlServerSideDiffDryRunApplier) runResourceCommand(obj *unstructure
 	stderr := stderrBuf.String()
 
 	if stderr != "" && stdout == "" {
-		err := fmt.Errorf("Server-side dry run apply had non-empty stderr: %s", stderr)
+		err := fmt.Errorf("server-side dry run apply had non-empty stderr: %s", stderr)
 		k.log.Error(err, "server-side diff")
 		return "", err
 	}
@@ -395,7 +395,7 @@ func newApplyOptionsCommon(config *rest.Config, fact cmdutil.Factory, ioStreams 
 		return nil, err
 	}
 
-	o.DeleteOptions.FilenameOptions.Filenames = []string{fileName}
+	o.DeleteOptions.Filenames = []string{fileName}
 	o.Namespace = obj.GetNamespace()
 	o.DeleteOptions.ForceDeletion = force
 	o.DryRunStrategy = dryRunStrategy
@@ -538,7 +538,7 @@ func (k *kubectlResourceOperations) newReplaceOptions(config *rest.Config, f cmd
 		return printer.PrintObj(obj, o.Out)
 	}
 
-	o.DeleteOptions.FilenameOptions.Filenames = []string{fileName}
+	o.DeleteOptions.Filenames = []string{fileName}
 	o.Namespace = namespace
 	o.DeleteOptions.ForceDeletion = force
 	return o, nil


### PR DESCRIPTION
I just ran the migrate tool and removed the `generated: lax` lines from .golangci.yaml (they didn't have any effect).