### PR TITLE
fix: Server-Side diff removed fields missing in diff

### DIFF
--- a/pkg/diff/testdata/data.go
+++ b/pkg/diff/testdata/data.go
@@ -68,4 +68,13 @@ var (
 
 	//go:embed ssd-deploy-with-manual-apply-predicted-live.json
 	DeploymentApplyPredictedLiveJSONSSD string
+
+	//go:embed ssd-svc-label-live.yaml
+	ServiceLiveLabelYAMLSSD string
+
+	//go:embed ssd-svc-no-label-config.yaml
+	ServiceConfigNoLabelYAMLSSD string
+
+	//go:embed ssd-svc-no-label-predicted-live.json
+	ServicePredictedLiveNoLabelJSONSSD string
 )

--- a/pkg/diff/testdata/ssd-svc-label-live.yaml
+++ b/pkg/diff/testdata/ssd-svc-label-live.yaml
@@ -1,0 +1,50 @@
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: "2025-05-16T19:01:22Z"
+  labels:
+    app.kubernetes.io/instance: httpbin
+    delete-me: delete-value
+  managedFields:
+    - apiVersion: v1
+      fieldsType: FieldsV1
+      fieldsV1:
+        f:metadata:
+          f:labels:
+            f:app.kubernetes.io/instance: {}
+            f:delete-me: {}
+        f:spec:
+          f:ports:
+            k:{"port":7777,"protocol":"TCP"}:
+              .: {}
+              f:name: {}
+              f:port: {}
+              f:protocol: {}
+              f:targetPort: {}
+          f:selector: {}
+      manager: argocd-controller
+      operation: Apply
+      time: "2025-05-16T19:01:22Z"
+  name: httpbin-svc
+  namespace: httpbin
+  resourceVersion: "159005"
+  uid: 61a7a0c2-d973-4333-bbd6-c06ba1c00190
+spec:
+  clusterIP: 10.96.59.144
+  clusterIPs:
+    - 10.96.59.144
+  internalTrafficPolicy: Cluster
+  ipFamilies:
+    - IPv4
+  ipFamilyPolicy: SingleStack
+  ports:
+    - name: http-port
+      port: 7777
+      protocol: TCP
+      targetPort: 80
+  selector:
+    app: httpbin
+  sessionAffinity: None
+  type: ClusterIP
+status:
+  loadBalancer: {}

--- a/pkg/diff/testdata/ssd-svc-no-label-config.yaml
+++ b/pkg/diff/testdata/ssd-svc-no-label-config.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/instance: httpbin
+  name: httpbin-svc
+  namespace: httpbin
+spec:
+  ports:
+    - name: http-port
+      port: 7777
+      protocol: TCP
+      targetPort: 80
+  selector:
+    app: httpbin

--- a/pkg/diff/testdata/ssd-svc-no-label-predicted-live.json
+++ b/pkg/diff/testdata/ssd-svc-no-label-predicted-live.json
@@ -1,0 +1,69 @@
+{
+  "apiVersion": "v1",
+  "kind": "Service",
+  "metadata": {
+    "creationTimestamp": "2025-05-16T19:01:22Z",
+    "labels": {
+      "app.kubernetes.io/instance": "httpbin"
+    },
+    "managedFields": [
+      {
+        "apiVersion": "v1",
+        "fieldsType": "FieldsV1",
+        "fieldsV1": {
+          "f:metadata": {
+            "f:labels": {
+              "f:app.kubernetes.io/instance": {}
+            }
+          },
+          "f:spec": {
+            "f:ports": {
+              "k:{\"port\":7777,\"protocol\":\"TCP\"}": {
+                ".": {},
+                "f:name": {},
+                "f:port": {},
+                "f:protocol": {},
+                "f:targetPort": {}
+              }
+            },
+            "f:selector": {}
+          }
+        },
+        "manager": "argocd-controller",
+        "operation": "Apply",
+        "time": "2025-05-16T19:02:57Z"
+      }
+    ],
+    "name": "httpbin-svc",
+    "namespace": "httpbin",
+    "resourceVersion": "159005",
+    "uid": "61a7a0c2-d973-4333-bbd6-c06ba1c00190"
+  },
+  "spec": {
+    "clusterIP": "10.96.59.144",
+    "clusterIPs": [
+      "10.96.59.144"
+    ],
+    "internalTrafficPolicy": "Cluster",
+    "ipFamilies": [
+      "IPv4"
+    ],
+    "ipFamilyPolicy": "SingleStack",
+    "ports": [
+      {
+        "name": "http-port",
+        "port": 7777,
+        "protocol": "TCP",
+        "targetPort": 80
+      }
+    ],
+    "selector": {
+      "app": "httpbin"
+    },
+    "sessionAffinity": "None",
+    "type": "ClusterIP"
+  },
+  "status": {
+    "loadBalancer": {}
+  }
+}


### PR DESCRIPTION
fixes https://github.com/argoproj/argo-cd/issues/23016 a bug that caused removed fields from predictedLive to be added back to predicted live resulting in removal of fields not showing in the diff