### PR TITLE
Feature skip dryrun in all cases

### DIFF
--- a/pkg/sync/sync_context_test.go
+++ b/pkg/sync/sync_context_test.go
@@ -1212,7 +1212,8 @@ func TestNamespaceAutoCreationForNonExistingNs(t *testing.T) {
 
 		fakeDisco := syncCtx.disco.(*fakedisco.FakeDiscovery)
 		fakeDisco.Resources = []*metav1.APIResourceList{
-			{GroupVersion: "v1",
+			{
+				GroupVersion: "v1",
 				APIResources: []metav1.APIResource{
 					{Name: "pods", Kind: "Pod", Namespaced: true, Verbs: metav1.Verbs{"get", "list", "watch", "create", "update", "patch", "delete"}},
 				},
@@ -1254,7 +1255,8 @@ func TestNamespaceAutoCreationForNonExistingNs(t *testing.T) {
 
 		fakeDisco := syncCtx.disco.(*fakedisco.FakeDiscovery)
 		fakeDisco.Resources = []*metav1.APIResourceList{
-			{GroupVersion: "v1",
+			{
+				GroupVersion: "v1",
 				APIResources: []metav1.APIResource{
 					{Name: "pods", Kind: "Pod", Namespaced: true, Verbs: metav1.Verbs{"get", "list", "watch", "create", "update", "patch", "delete"}},
 				},
@@ -1265,7 +1267,6 @@ func TestNamespaceAutoCreationForNonExistingNs(t *testing.T) {
 		syncCtx.skipDryRun = true
 		tasks, successful := syncCtx.getSyncTasks()
 
-		//assert.True(t, creatorCalled)
 		assert.True(t, successful)
 		assert.Len(t, tasks, 1)
 		assert.Equal(t, &syncTask{

--- a/pkg/sync/sync_context_test.go
+++ b/pkg/sync/sync_context_test.go
@@ -1241,9 +1241,15 @@ func TestNamespaceAutoCreationForNonExistingNs(t *testing.T) {
 	})
 
 	t.Run("Skip dryrun should be set to false if the object is already created", func(t *testing.T) {
+		pod1 := testingutils.NewPod()
+		pod1.SetName("pod-dryrun2")
+
+		syncCtx := newTestSyncCtx(nil, WithResourcesFilter(func(key kube.ResourceKey, _ *unstructured.Unstructured, _ *unstructured.Unstructured) bool {
+			return key.Kind == pod1.GetKind() && key.Name == pod1.GetName()
+		}))
 		syncCtx.resources = groupResources(ReconciliationResult{
-			Live:   []*unstructured.Unstructured{pod},
-			Target: []*unstructured.Unstructured{pod},
+			Live:   []*unstructured.Unstructured{pod1},
+			Target: []*unstructured.Unstructured{pod1},
 		})
 
 		fakeDisco := syncCtx.disco.(*fakedisco.FakeDiscovery)

--- a/pkg/sync/sync_context_test.go
+++ b/pkg/sync/sync_context_test.go
@@ -1208,6 +1208,7 @@ func TestNamespaceAutoCreationForNonExistingNs(t *testing.T) {
 }
 
 func testSkipDryRunOnlySetWhenResouceIsntCreated(t *testing.T, objectExists bool, podName string) {
+	t.Helper()
 	pod1 := testingutils.NewPod()
 	pod1.SetName(podName)
 

--- a/pkg/sync/sync_context_test.go
+++ b/pkg/sync/sync_context_test.go
@@ -1207,9 +1207,9 @@ func TestNamespaceAutoCreationForNonExistingNs(t *testing.T) {
 	})
 }
 
-func testSkipDryRunOnlySetWhenResouceIsntCreated(t *testing.T, objectExists bool, Podname string) {
+func testSkipDryRunOnlySetWhenResouceIsntCreated(t *testing.T, objectExists bool, podName string) {
 	pod1 := testingutils.NewPod()
-	pod1.SetName(Podname)
+	pod1.SetName(podName)
 
 	syncCtx := newTestSyncCtx(nil, WithResourcesFilter(func(key kube.ResourceKey, _ *unstructured.Unstructured, _ *unstructured.Unstructured) bool {
 		return key.Kind == pod1.GetKind() && key.Name == pod1.GetName()


### PR DESCRIPTION
This is an extention to solve the issue that the validation fails on creating resources in a not yet existing namespace.
https://github.com/argoproj/argo-cd/issues/21788
and a followup to:
https://github.com/argoproj/gitops-engine/pull/708

By setting the skipDryRun you can skip the validation in your sync action allowing the resources that can already be created (the namespace) to be created and the other resources in another sync wave.
In the old situation it only worked for CRD's which made it redundant to skipDryRunOnMissingResource. By moving it out of the err!=nil check it can be used by all type of resources.

If oke I will join the meeting next thursday to explain the requested change.