### PR TITLE
Chore: Remove Endpoints ownerRef workaround for fixed k8s issue #28483

### DIFF
--- a/pkg/cache/references.go
+++ b/pkg/cache/references.go
@@ -24,14 +24,6 @@ func (c *clusterCache) resolveResourceReferences(un *unstructured.Unstructured) 
 	gvk := un.GroupVersionKind()
 
 	switch {
-	// Special case for endpoint. Remove after https://github.com/kubernetes/kubernetes/issues/28483 is fixed
-	case gvk.Group == "" && gvk.Kind == kube.EndpointsKind && len(ownerRefs) == 0:
-		ownerRefs = append(ownerRefs, metav1.OwnerReference{
-			Name:       un.GetName(),
-			Kind:       kube.ServiceKind,
-			APIVersion: "v1",
-		})
-
 	// Special case for Operator Lifecycle Manager ClusterServiceVersion:
 	case gvk.Group == "operators.coreos.com" && gvk.Kind == "ClusterServiceVersion":
 		if un.GetAnnotations()["olm.operatorGroup"] != "" {


### PR DESCRIPTION
What does this PR do?

This PR removes the special handling logic for Kubernetes Endpoints resources that was added as a workaround for an upstream bug.

The code responsible for adding a Service as an owner reference to Endpoints with no existing owners is now deleted.

Why is this change being made?

The original issue, tracked in [kubernetes/kubernetes#28483](https://github.com/kubernetes/kubernetes/issues/28483), has been fixed in recent versions of Kubernetes. 