### PR TITLE
fix: invalidate cluster cache after sync operations

### DIFF
--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -84,6 +84,13 @@ func (e *gitOpsEngine) Sync(ctx context.Context,
 		return nil, fmt.Errorf("failed to diff objects: %w", err)
 	}
 	opts = append(opts, sync.WithSkipHooks(!diffRes.Modified))
+
+	// Add cache invalidation callback to invalidate cache for modified resources after sync
+	opts = append(opts, sync.WithCacheInvalidationCallback(func() {
+		// Invalidate the entire cache to ensure consistency
+		e.cache.Invalidate()
+	}))
+
 	syncCtx, cleanup, err := sync.NewSyncContext(revision, result, e.config, e.config, e.kubectl, namespace, e.cache.GetOpenAPISchema(), opts...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create sync context: %w", err)

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -74,6 +74,13 @@ func (e *gitOpsEngine) Sync(ctx context.Context,
 	namespace string,
 	opts ...sync.SyncOpt,
 ) ([]common.ResourceSyncResult, error) {
+	// Ensure cache is synced before getting managed live objects
+	// This forces a refresh if the cache was invalidated
+	err := e.cache.EnsureSynced()
+	if err != nil {
+		return nil, fmt.Errorf("failed to ensure cache is synced: %w", err)
+	}
+
 	managedResources, err := e.cache.GetManagedLiveObjs(resources, isManaged)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get managed live objects: %w", err)

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -93,9 +93,11 @@ func (e *gitOpsEngine) Sync(ctx context.Context,
 	opts = append(opts, sync.WithSkipHooks(!diffRes.Modified))
 
 	// Add cache invalidation callback to invalidate cache for modified resources after sync
-	opts = append(opts, sync.WithCacheInvalidationCallback(func() {
-		// Invalidate the entire cache to ensure consistency
-		e.cache.Invalidate()
+	opts = append(opts, sync.WithCacheInvalidationCallback(func(modifiedResources []kube.ResourceKey) {
+		// Only invalidate the specific resources that were modified
+		if len(modifiedResources) > 0 {
+			e.cache.InvalidateResources(modifiedResources)
+		}
 	}))
 
 	syncCtx, cleanup, err := sync.NewSyncContext(revision, result, e.config, e.config, e.kubectl, namespace, e.cache.GetOpenAPISchema(), opts...)

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -78,7 +78,7 @@ func (e *gitOpsEngine) Sync(ctx context.Context,
 	// This forces a refresh if the cache was invalidated
 	err := e.cache.EnsureSynced()
 	if err != nil {
-		return nil, fmt.Errorf("failed to ensure cache is synced: %w", err)
+		return nil, fmt.Errorf("error during sync: failed to ensure cache is synced: %w", err)
 	}
 
 	managedResources, err := e.cache.GetManagedLiveObjs(resources, isManaged)

--- a/pkg/sync/sync_context_test.go
+++ b/pkg/sync/sync_context_test.go
@@ -362,7 +362,7 @@ func TestSyncCreateFailure(t *testing.T) {
 		Commands: map[string]kubetest.KubectlOutput{
 			testSvc.GetName(): {
 				Output: "",
-				Err:    apierrors.NewNotFound(schema.GroupResource{}, testingutils.FakeArgoCDNamespace),
+				Err:    errors.New("invalid object failing dry-run"),
 			},
 		},
 	}
@@ -371,7 +371,7 @@ func TestSyncCreateFailure(t *testing.T) {
 		Commands: map[string]kubetest.KubectlOutput{
 			testSvc.GetName(): {
 				Output: "",
-				Err:    apierrors.NewNotFound(schema.GroupResource{}, testingutils.FakeArgoCDNamespace),
+				Err:    errors.New("invalid object failing dry-run"),
 			},
 		},
 	}


### PR DESCRIPTION
fixes https://github.com/argoproj/argo-cd/issues/20458

There have been several times after a sync that the diff shows the live resource before the sync, causing incorrect diffs. This change will ensure if there is a sync with a valid task (non no-op) then we invalidate the cache. We only invalidate cache for resources that were modified to save on operational cost
This is guaranteeing fresh data for subsequent diff calculations

This could also help/fix an issue with CRDs as previously after a CRD schema changes and is synced, we run into a diff error because diff is using stale schema