### PR TITLE
fix: call validate on all options to prevent from errors

### DIFF
--- a/pkg/utils/kube/resource_ops.go
+++ b/pkg/utils/kube/resource_ops.go
@@ -238,10 +238,6 @@ func (k *kubectlResourceOperations) ReplaceResource(ctx context.Context, obj *un
 			return err
 		}
 
-		if err := replaceOptions.Validate(); err != nil {
-			return fmt.Errorf("error validating replace options: %w", err)
-		}
-
 		return replaceOptions.Run(k.fact)
 	})
 }
@@ -433,6 +429,10 @@ func (k *kubectlServerSideDiffDryRunApplier) newApplyOptions(ioStreams genericcl
 	}
 
 	o.ForceConflicts = true
+
+	if err := o.Validate(); err != nil {
+		return nil, fmt.Errorf("error validating options: %w", err)
+	}
 	return o, nil
 }
 
@@ -461,6 +461,10 @@ func (k *kubectlResourceOperations) newApplyOptions(ioStreams genericclioptions.
 
 	if serverSideApply {
 		o.ForceConflicts = true
+	}
+
+	if err := o.Validate(); err != nil {
+		return nil, fmt.Errorf("error validating options: %w", err)
 	}
 	return o, nil
 }
@@ -496,6 +500,10 @@ func (k *kubectlResourceOperations) newCreateOptions(ioStreams genericclioptions
 		return printer.PrintObj(obj, o.Out)
 	}
 	o.FilenameOptions.Filenames = []string{fileName}
+
+	if err := o.Validate(); err != nil {
+		return nil, fmt.Errorf("error validating options: %w", err)
+	}
 	return o, nil
 }
 
@@ -551,6 +559,9 @@ func (k *kubectlResourceOperations) newReplaceOptions(config *rest.Config, f cmd
 		o.DeleteOptions.ForceDeletion = force
 	}
 
+	if err := o.Validate(); err != nil {
+		return nil, fmt.Errorf("error validating options: %w", err)
+	}
 	return o, nil
 }
 
@@ -580,6 +591,10 @@ func newReconcileOptions(f cmdutil.Factory, kubeClient *kubernetes.Clientset, fi
 		return nil, fmt.Errorf("error configuring printer: %w", err)
 	}
 	o.PrintObject = printer.PrintObj
+
+	if err := o.Validate(); err != nil {
+		return nil, fmt.Errorf("error validating options: %w", err)
+	}
 	return o, nil
 }
 


### PR DESCRIPTION
The code is simple, but unit test framework is not setup to test the KubectlResourceOperation struct. 

This struct is mocked by the sync context tests.

The unit tests will come in another PR (https://github.com/argoproj/gitops-engine/pull/758), but we can ship this fix first. 