### PR TITLE
fix(sync): ApplyOutOfSyncOnly=true sync option is not honoured for cluster scoped resources

### DIFF
--- a/pkg/sync/sync_context_test.go
+++ b/pkg/sync/sync_context_test.go
@@ -393,10 +393,13 @@ func TestSyncCreateFailure(t *testing.T) {
 func TestSync_ApplyOutOfSyncOnly(t *testing.T) {
 	pod1 := testingutils.NewPod()
 	pod1.SetName("pod-1")
+	pod1.SetNamespace("fake-argocd-ns")
 	pod2 := testingutils.NewPod()
 	pod2.SetName("pod-2")
+	pod2.SetNamespace("fake-argocd-ns")
 	pod3 := testingutils.NewPod()
 	pod3.SetName("pod-3")
+	pod3.SetNamespace("fake-argocd-ns")
 
 	syncCtx := newTestSyncCtx(nil)
 	syncCtx.applyOutOfSyncOnly = true

--- a/pkg/sync/sync_context_test.go
+++ b/pkg/sync/sync_context_test.go
@@ -550,8 +550,8 @@ func TestSync_ApplyOutOfSyncOnly_ClusterResources(t *testing.T) {
 		assert.Equal(t, synccommon.OperationSucceeded, phase)
 		assert.Len(t, resources, 3)
 	})
-
 }
+
 func TestSyncPruneFailure(t *testing.T) {
 	syncCtx := newTestSyncCtx(nil, WithOperationSettings(false, true, false, false))
 	mockKubectl := &kubetest.MockKubectlCmd{

--- a/pkg/sync/sync_context_test.go
+++ b/pkg/sync/sync_context_test.go
@@ -524,9 +524,11 @@ func TestSync_ApplyOutOfSyncOnly_ClusterResources(t *testing.T) {
 
 	ns2Target := testingutils.NewNamespace()
 	ns2Target.SetName("ns-2")
-	// set namespace for a cluster scoped resource. This is to simulate Argo CD application controller behaviour,
-	// where it sets the destination.namespace for all resources that does not have a namespace set, irrespective of
-	// whether the resource is a cluster scoped or a namespace scoped.
+	// set namespace for a cluster scoped resource. This is to simulate the behaviour, where the Application's
+	// spec.destination.namespace is set for all resources that does not have a namespace set, irrespective of whether
+	// the resource is cluster scoped or namespace scoped.
+	//
+	// Refer to https://github.com/argoproj/gitops-engine/blob/8007df5f6c5dd78a1a8cef73569468ce4d83682c/pkg/sync/sync_context.go#L827-L833
 	ns2Target.SetNamespace("ns-2")
 
 	syncCtx := newTestSyncCtx(nil, WithResourceModificationChecker(true, diffResultListClusterResource()))

--- a/pkg/sync/sync_context_test.go
+++ b/pkg/sync/sync_context_test.go
@@ -512,21 +512,24 @@ func TestSync_ApplyOutOfSyncOnly(t *testing.T) {
 func TestSync_ApplyOutOfSyncOnly_ClusterResources(t *testing.T) {
 	ns1 := testingutils.NewNamespace()
 	ns1.SetName("ns-1")
+	ns1.SetNamespace("")
 
 	ns2 := testingutils.NewNamespace()
 	ns2.SetName("ns-2")
-
-	ns2Target := testingutils.NewNamespace()
-	ns2Target.SetName("ns-2")
-	ns2Target.SetNamespace("ns-2")
+	ns1.SetNamespace("")
 
 	ns3 := testingutils.NewNamespace()
 	ns3.SetName("ns-3")
+	ns3.SetNamespace("")
 
-	syncCtx := newTestSyncCtx(nil, WithResourceModificationChecker(true, &diff.DiffResultList{
-		Diffs:    []diff.DiffResult{},
-		Modified: false,
-	}))
+	ns2Target := testingutils.NewNamespace()
+	ns2Target.SetName("ns-2")
+	// set namespace for a cluster scoped resource. This is to simulate Argo CD application controller behaviour,
+	// where it sets the destination.namespace for all resources that does not have a namespace set, irrespective of
+	// whether the resource is a cluster scoped or a namespace scoped.
+	ns2Target.SetNamespace("ns-2")
+
+	syncCtx := newTestSyncCtx(nil, WithResourceModificationChecker(true, diffResultListClusterResource()))
 	syncCtx.applyOutOfSyncOnly = true
 	fakeDisco := syncCtx.disco.(*fakedisco.FakeDiscovery)
 	fakeDisco.Resources = []*metav1.APIResourceList{
@@ -539,7 +542,6 @@ func TestSync_ApplyOutOfSyncOnly_ClusterResources(t *testing.T) {
 	}
 
 	t.Run("cluster resource with target ns having namespace filled", func(t *testing.T) {
-		syncCtx.modificationResult = nil
 		syncCtx.resources = groupResources(ReconciliationResult{
 			Live:   []*unstructured.Unstructured{nil, ns2, ns3},
 			Target: []*unstructured.Unstructured{ns1, ns2Target, ns3},
@@ -548,7 +550,24 @@ func TestSync_ApplyOutOfSyncOnly_ClusterResources(t *testing.T) {
 		syncCtx.Sync()
 		phase, _, resources := syncCtx.GetState()
 		assert.Equal(t, synccommon.OperationSucceeded, phase)
-		assert.Len(t, resources, 3)
+		assert.Len(t, resources, 1)
+		for _, r := range resources {
+			switch r.ResourceKey.Name {
+			case "ns-1":
+				// ns-1 namespace does not exist yet in the cluster, so it must create it and resource must go to
+				// synced state.
+				assert.Equal(t, synccommon.ResultCodeSynced, r.Status)
+			case "ns-2":
+				// ns-2 namespace already exist and is synced. However, the target resource has metadata.namespace set for
+				// a cluster resource. This namespace must not be synced again, as the object already exists and
+				// a change in namespace for a cluster resource has no meaning and hence must not be treated as an
+				// out-of-sync resource.
+				t.Error("ns-2 should have been skipped, as no change")
+			case "ns-3":
+				// ns-3 namespace exists and there is no change in the target's metadata.namespace value. So it must not try to sync again.
+				t.Error("ns-3 should have been skipped, as no change")
+			}
+		}
 	})
 }
 
@@ -2307,4 +2326,29 @@ func TestNeedsClientSideApplyMigration(t *testing.T) {
 			assert.Equal(t, tt.expected, result)
 		})
 	}
+}
+
+func diffResultListClusterResource() *diff.DiffResultList {
+	ns1 := testingutils.NewNamespace()
+	ns1.SetName("ns-1")
+	ns2 := testingutils.NewNamespace()
+	ns2.SetName("ns-2")
+	ns3 := testingutils.NewNamespace()
+	ns3.SetName("ns-3")
+
+	diffResultList := diff.DiffResultList{
+		Modified: true,
+		Diffs:    []diff.DiffResult{},
+	}
+
+	nsBytes, _ := json.Marshal(ns1)
+	diffResultList.Diffs = append(diffResultList.Diffs, diff.DiffResult{NormalizedLive: nsBytes, PredictedLive: nsBytes, Modified: false})
+
+	nsBytes, _ = json.Marshal(ns2)
+	diffResultList.Diffs = append(diffResultList.Diffs, diff.DiffResult{NormalizedLive: nsBytes, PredictedLive: nsBytes, Modified: false})
+
+	nsBytes, _ = json.Marshal(ns3)
+	diffResultList.Diffs = append(diffResultList.Diffs, diff.DiffResult{NormalizedLive: nsBytes, PredictedLive: nsBytes, Modified: false})
+
+	return &diffResultList
 }

--- a/pkg/sync/sync_task.go
+++ b/pkg/sync/sync_task.go
@@ -151,6 +151,6 @@ func (t *syncTask) resourceKey() kube.ResourceKey {
 	resourceKey := kube.GetResourceKey(t.obj())
 	if t.liveObj != nil {
 		resourceKey.Namespace = t.liveObj.GetNamespace()
-	}// for handling cluster resources
+	}
 	return resourceKey
 }

--- a/pkg/sync/sync_task.go
+++ b/pkg/sync/sync_task.go
@@ -151,6 +151,6 @@ func (t *syncTask) resourceKey() kube.ResourceKey {
 	resourceKey := kube.GetResourceKey(t.obj())
 	if t.liveObj != nil {
 		resourceKey.Namespace = t.liveObj.GetNamespace()
-	}
+	}// for handling cluster resources
 	return resourceKey
 }

--- a/pkg/sync/sync_task.go
+++ b/pkg/sync/sync_task.go
@@ -148,8 +148,9 @@ func (t *syncTask) deleteOnPhaseFailed() bool {
 }
 
 func (t *syncTask) resourceKey() kube.ResourceKey {
+	resourceKey := kube.GetResourceKey(t.obj())
 	if t.liveObj != nil {
-		return kube.GetResourceKey(t.liveObj)
+		resourceKey.Namespace = t.liveObj.GetNamespace()
 	}
-	return kube.GetResourceKey(t.obj())
+	return resourceKey
 }

--- a/pkg/sync/sync_task.go
+++ b/pkg/sync/sync_task.go
@@ -150,6 +150,14 @@ func (t *syncTask) deleteOnPhaseFailed() bool {
 func (t *syncTask) resourceKey() kube.ResourceKey {
 	resourceKey := kube.GetResourceKey(t.obj())
 	if t.liveObj != nil {
+		// t.targetObj has a namespace set for cluster-scoped resources, which causes kube.GetResourceKey()
+		// to produce an incorrect key with the namespace included. For example:
+		// rbac.authorization.k8s.io/ClusterRole/my-namespace/my-cluster-role
+		// instead of the correct rbac.authorization.k8s.io/ClusterRole//my-cluster-role.
+		// To prevent resource lookup issues, we always rely on the namespace of the live object if it is available.
+		// This logic will work for both cluster scoped and namespace scoped resources.
+		//
+		// Refer to https://github.com/argoproj/gitops-engine/blob/8007df5f6c5dd78a1a8cef73569468ce4d83682c/pkg/sync/sync_context.go#L827-L833
 		resourceKey.Namespace = t.liveObj.GetNamespace()
 	}
 	return resourceKey

--- a/pkg/sync/sync_task.go
+++ b/pkg/sync/sync_task.go
@@ -148,5 +148,8 @@ func (t *syncTask) deleteOnPhaseFailed() bool {
 }
 
 func (t *syncTask) resourceKey() kube.ResourceKey {
+	if t.liveObj != nil {
+		return kube.GetResourceKey(t.liveObj)
+	}
 	return kube.GetResourceKey(t.obj())
 }


### PR DESCRIPTION
Fixes https://github.com/argoproj/argo-cd/issues/24242

The root cause of the issue is, when the `resourceKey` is calculated from the object associated with`syncTask`, it is calculated from the desired object instead of the live object. In the desired object, the `resourceKey` will be filled in with the destination namespace configured in the Application even for cluster scoped resource, where the namespace must be   empty.

<img width="845" height="313" alt="Screenshot 2025-08-23 at 6 41 41 PM" src="https://github.com/user-attachments/assets/80f51bc9-89ac-4f56-9c40-fc2301a890fb" />
<img width="988" height="244" alt="Screenshot 2025-08-23 at 6 42 10 PM" src="https://github.com/user-attachments/assets/91890494-2208-43cb-9599-df5a3d9e8dd7" />

For fixing the issue, when the `syncTask` contains a `liveObj`, calculate the `resourceKey` using the live object instead of the desired object set in the `syncTask`. This desired object contains the application destination namespace even for cluster scoped resources.