### PR TITLE
fix: Update checkPermissions to not exit the namespace loop after the first namespace regardless

### DIFF
--- a/pkg/cache/cluster.go
+++ b/pkg/cache/cluster.go
@@ -845,10 +845,9 @@ func (c *clusterCache) checkPermission(ctx context.Context, reviewInterface auth
 			if resp != nil && resp.Status.Allowed {
 				return true, nil
 			}
-			// unsupported, remove from watch list
-			//nolint:staticcheck //FIXME
-			return false, nil
 		}
+		// unsupported, remove from watch list
+		return false, nil
 	}
 	// checkPermission follows the same logic of determining namespace/cluster resource as the processApi function
 	// so if neither of the cases match it means the controller will not watch for it so it is safe to return true.


### PR DESCRIPTION
Helps with https://github.com/argoproj/argo-cd/issues/23855

The namespace loop would be exited after the first namespace in all cases, which is wrong. The correct thing to do seems to only return false after all namespaces were checked and none resulted in true.